### PR TITLE
feature 18 ユーザ登録の単体テスト

### DIFF
--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -100,109 +100,109 @@ export class AuthController {
     }
   }
 
-  // static forgotPassword = async (
-  //   req: Request,
-  //   res: Response,
-  // ): Promise<void> => {
-  //   const { email } = req.body
-  //   const user = await User.findOne({ where: { email } })
-  //   if (!user) {
-  //     res.status(401).json({ error: 'ユーザが見つかりません' })
-  //   }
-  //   user.token = generateToken()
-  //   await user.save()
+  static forgotPassword = async (
+    req: Request,
+    res: Response,
+  ): Promise<void> => {
+    const { email } = req.body
+    const user = await User.findOne({ where: { email } })
+    if (!user) {
+      res.status(401).json({ error: 'ユーザが見つかりません' })
+    }
+    user.token = generateToken()
+    await user.save()
 
-  //   await AuthEmail.sendResetPasswordEmail({
-  //     name: user.name,
-  //     email: user.email,
-  //     token: user.token,
-  //   })
-  //   res.status(201).json({
-  //     message: 'パスワードをリセットしました。メールを確認してください',
-  //     email: { to: user.email, token: user.token },
-  //   })
-  // }
+    await AuthEmail.sendResetPasswordEmail({
+      name: user.name,
+      email: user.email,
+      token: user.token,
+    })
+    res.status(201).json({
+      message: 'パスワードをリセットしました。メールを確認してください',
+      email: { to: user.email, token: user.token },
+    })
+  }
 
-  // static validateToken = async (req: Request, res: Response): Promise<void> => {
-  //   //TODO: パスワードリセット時に生成したtokenが有効か確認する
-  //   const { token } = req.body
-  //   const user = await User.findOne({ where: { token } })
-  //   if (!user) {
-  //     res.status(401).json({ error: 'ユーザが見つかりません' })
-  //   }
-  //   res.status(200).json({
-  //     message: '有効なトークンです。新しいパスワードを設定してください。',
-  //   })
-  // }
+  static validateToken = async (req: Request, res: Response): Promise<void> => {
+    //TODO: パスワードリセット時に生成したtokenが有効か確認する
+    const { token } = req.body
+    const user = await User.findOne({ where: { token } })
+    if (!user) {
+      res.status(401).json({ error: 'ユーザが見つかりません' })
+    }
+    res.status(200).json({
+      message: '有効なトークンです。新しいパスワードを設定してください。',
+    })
+  }
 
-  // static resetPasswordWithToken = async (
-  //   req: Request,
-  //   res: Response,
-  // ): Promise<void> => {
-  //   const { token } = req.params
-  //   const { password } = req.body
+  static resetPasswordWithToken = async (
+    req: Request,
+    res: Response,
+  ): Promise<void> => {
+    const { token } = req.params
+    const { password } = req.body
 
-  //   try {
-  //     const user = await User.findOne({ where: { token } })
+    try {
+      const user = await User.findOne({ where: { token } })
 
-  //     if (!user) {
-  //       res.status(401).json({ error: 'ユーザが見つかりません' })
-  //       return
-  //     }
+      if (!user) {
+        res.status(401).json({ error: 'ユーザが見つかりません' })
+        return
+      }
 
-  //     // パスワードの再設定時も、ハッシュ化して登録する
-  //     user.password = await hashPassword(password)
-  //     // 認証コード用のtokenが正しいことが確認出来たら、tokenをnullにして無効にする
-  //     user.token = null
-  //     await user.save()
+      // パスワードの再設定時も、ハッシュ化して登録する
+      user.password = await hashPassword(password)
+      // 認証コード用のtokenが正しいことが確認出来たら、tokenをnullにして無効にする
+      user.token = null
+      await user.save()
 
-  //     res.status(200).json({ message: 'パスワードが更新されました' })
-  //   } catch (error) {
-  //     res.status(500).json({ error: 'サーバーエラーが発生しました' })
-  //   }
-  // }
+      res.status(200).json({ message: 'パスワードが更新されました' })
+    } catch (error) {
+      res.status(500).json({ error: 'サーバーエラーが発生しました' })
+    }
+  }
 
-  // static user = async (req: Request, res: Response): Promise<void> => {
-  //   res.json(req.user)
-  // }
-  // static updateUser = async (req: Request, res: Response): Promise<void> => {
-  //   res.json('認証されたユーザの更新APIテスト')
-  // }
+  static user = async (req: Request, res: Response): Promise<void> => {
+    res.json(req.user)
+  }
+  static updateUser = async (req: Request, res: Response): Promise<void> => {
+    res.json('認証されたユーザの更新APIテスト')
+  }
 
-  // static updateCurrentUserPassword = async (
-  //   req: Request,
-  //   res: Response,
-  // ): Promise<void> => {
-  //   const { current_password, password } = req.body
-  //   const { id } = req.user
-  //   const user = await User.findByPk(id)
+  static updateCurrentUserPassword = async (
+    req: Request,
+    res: Response,
+  ): Promise<void> => {
+    const { current_password, password } = req.body
+    const { id } = req.user
+    const user = await User.findByPk(id)
 
-  //   //MEMO: IDから取得したユーザのパスワードと、current_passwordが一致するか確認
-  //   const isCheckPasswordCorrect = await checkPassword(
-  //     current_password,
-  //     user.password,
-  //   )
-  //   if (!isCheckPasswordCorrect) {
-  //     res.status(401).json({ error: '現在のパスワードが間違っています' })
-  //     return
-  //   }
-  //   //MEMO: 現在のパスワードの入力が正しい場合、再設定したパスワードを保存
-  //   user.password = await hashPassword(password)
-  //   await user.save()
-  //   res.status(200).json({ message: 'パスワードが更新されました' })
-  // }
+    //MEMO: IDから取得したユーザのパスワードと、current_passwordが一致するか確認
+    const isCheckPasswordCorrect = await checkPassword(
+      current_password,
+      user.password,
+    )
+    if (!isCheckPasswordCorrect) {
+      res.status(401).json({ error: '現在のパスワードが間違っています' })
+      return
+    }
+    //MEMO: 現在のパスワードの入力が正しい場合、再設定したパスワードを保存
+    user.password = await hashPassword(password)
+    await user.save()
+    res.status(200).json({ message: 'パスワードが更新されました' })
+  }
 
-  // static checkPassword = async (req: Request, res: Response): Promise<void> => {
-  //   const { password } = req.body
-  //   const { id } = req.user
+  static checkPassword = async (req: Request, res: Response): Promise<void> => {
+    const { password } = req.body
+    const { id } = req.user
 
-  //   const user = await User.findByPk(id)
+    const user = await User.findByPk(id)
 
-  //   const isCorrectPassword = await checkPassword(password, user.password)
-  //   if (!isCorrectPassword) {
-  //     res.status(401).json({ error: 'パスワードが間違っています' })
-  //     return
-  //   }
-  //   res.status(201).json({ message: 'パスワードは正しいです' })
-  // }
+    const isCorrectPassword = await checkPassword(password, user.password)
+    if (!isCorrectPassword) {
+      res.status(401).json({ error: 'パスワードが間違っています' })
+      return
+    }
+    res.status(201).json({ message: 'パスワードは正しいです' })
+  }
 }

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -7,7 +7,7 @@ import { generateJWT } from '../utils/jwt'
 import jwt from 'jsonwebtoken'
 
 export class AuthController {
-  static createAccount = async (req: Request, res: Response): Promise<void> => {
+  static createAccount = async (req: Request, res: Response) => {
     // res.json(req.body)
     const { email, password } = req.body
     const userExists = await User.findOne({ where: { email } })
@@ -15,9 +15,10 @@ export class AuthController {
       const error = new Error('そのメールアドレスは既に登録されています。')
       //MEMO: 競合がある場合、409エラーを使用する
       res.status(409).json({ error: error.message })
+      return;
     }
     try {
-      const user = new User(req.body)
+      const user = await User.create(req.body)
       user.password = await hashPassword(password)
       const token = generateToken()
       user.token = token
@@ -84,124 +85,124 @@ export class AuthController {
         return // 関数を終了させる
       }
 
-      const isPasswordCorrect = await checkPassword(password, user.password)
-      // console.log('Password correct:', isPasswordCorrect);
-      if (!isPasswordCorrect) {
-        res.status(401).json({ error: 'パスワードが間違っています' })
-        return // 関数を終了させる
-      }
+      //     const isPasswordCorrect = await checkPassword(password, user.password)
+      //     // console.log('Password correct:', isPasswordCorrect);
+      //     if (!isPasswordCorrect) {
+      //       res.status(401).json({ error: 'パスワードが間違っています' })
+      //       return // 関数を終了させる
+      //     }
 
-      // JWTの生成
-      const token = generateJWT(user.id)
-      res.json({ message: 'アカウントのログインに成功しました！', token })
-    } catch (error) {
-      res.status(500).json({ error: 'サーバーエラーが発生しました' })
+      //     // JWTの生成
+      //     const token = generateJWT(user.id)
+      //     res.json({ message: 'アカウントのログインに成功しました！', token })
+      //   } catch (error) {
+      //     res.status(500).json({ error: 'サーバーエラーが発生しました' })
+      //   }
+      // }
+
+      // static forgotPassword = async (
+      //   req: Request,
+      //   res: Response,
+      // ): Promise<void> => {
+      //   const { email } = req.body
+      //   const user = await User.findOne({ where: { email } })
+      //   if (!user) {
+      //     res.status(401).json({ error: 'ユーザが見つかりません' })
+      //   }
+      //   user.token = generateToken()
+      //   await user.save()
+
+      //   await AuthEmail.sendResetPasswordEmail({
+      //     name: user.name,
+      //     email: user.email,
+      //     token: user.token,
+      //   })
+      //   res.status(201).json({
+      //     message: 'パスワードをリセットしました。メールを確認してください',
+      //     email: { to: user.email, token: user.token },
+      //   })
+      // }
+
+      // static validateToken = async (req: Request, res: Response): Promise<void> => {
+      //   //TODO: パスワードリセット時に生成したtokenが有効か確認する
+      //   const { token } = req.body
+      //   const user = await User.findOne({ where: { token } })
+      //   if (!user) {
+      //     res.status(401).json({ error: 'ユーザが見つかりません' })
+      //   }
+      //   res.status(200).json({
+      //     message: '有効なトークンです。新しいパスワードを設定してください。',
+      //   })
+      // }
+
+      // static resetPasswordWithToken = async (
+      //   req: Request,
+      //   res: Response,
+      // ): Promise<void> => {
+      //   const { token } = req.params
+      //   const { password } = req.body
+
+      //   try {
+      //     const user = await User.findOne({ where: { token } })
+
+      //     if (!user) {
+      //       res.status(401).json({ error: 'ユーザが見つかりません' })
+      //       return
+      //     }
+
+      //     // パスワードの再設定時も、ハッシュ化して登録する
+      //     user.password = await hashPassword(password)
+      //     // 認証コード用のtokenが正しいことが確認出来たら、tokenをnullにして無効にする
+      //     user.token = null
+      //     await user.save()
+
+      //     res.status(200).json({ message: 'パスワードが更新されました' })
+      //   } catch (error) {
+      //     res.status(500).json({ error: 'サーバーエラーが発生しました' })
+      //   }
+      // }
+
+      // static user = async (req: Request, res: Response): Promise<void> => {
+      //   res.json(req.user)
+      // }
+      // static updateUser = async (req: Request, res: Response): Promise<void> => {
+      //   res.json('認証されたユーザの更新APIテスト')
+      // }
+
+      // static updateCurrentUserPassword = async (
+      //   req: Request,
+      //   res: Response,
+      // ): Promise<void> => {
+      //   const { current_password, password } = req.body
+      //   const { id } = req.user
+      //   const user = await User.findByPk(id)
+
+      //   //MEMO: IDから取得したユーザのパスワードと、current_passwordが一致するか確認
+      //   const isCheckPasswordCorrect = await checkPassword(
+      //     current_password,
+      //     user.password,
+      //   )
+      //   if (!isCheckPasswordCorrect) {
+      //     res.status(401).json({ error: '現在のパスワードが間違っています' })
+      //     return
+      //   }
+      //   //MEMO: 現在のパスワードの入力が正しい場合、再設定したパスワードを保存
+      //   user.password = await hashPassword(password)
+      //   await user.save()
+      //   res.status(200).json({ message: 'パスワードが更新されました' })
+      // }
+
+      // static checkPassword = async (req: Request, res: Response): Promise<void> => {
+      //   const { password } = req.body
+      //   const { id } = req.user
+
+      //   const user = await User.findByPk(id)
+
+      //   const isCorrectPassword = await checkPassword(password, user.password)
+      //   if (!isCorrectPassword) {
+      //     res.status(401).json({ error: 'パスワードが間違っています' })
+      //     return
+      //   }
+      //   res.status(201).json({ message: 'パスワードは正しいです' })
+      // }
     }
-  }
-
-  static forgotPassword = async (
-    req: Request,
-    res: Response,
-  ): Promise<void> => {
-    const { email } = req.body
-    const user = await User.findOne({ where: { email } })
-    if (!user) {
-      res.status(401).json({ error: 'ユーザが見つかりません' })
-    }
-    user.token = generateToken()
-    await user.save()
-
-    await AuthEmail.sendResetPasswordEmail({
-      name: user.name,
-      email: user.email,
-      token: user.token,
-    })
-    res.status(201).json({
-      message: 'パスワードをリセットしました。メールを確認してください',
-      email: { to: user.email, token: user.token },
-    })
-  }
-
-  static validateToken = async (req: Request, res: Response): Promise<void> => {
-    //TODO: パスワードリセット時に生成したtokenが有効か確認する
-    const { token } = req.body
-    const user = await User.findOne({ where: { token } })
-    if (!user) {
-      res.status(401).json({ error: 'ユーザが見つかりません' })
-    }
-    res.status(200).json({
-      message: '有効なトークンです。新しいパスワードを設定してください。',
-    })
-  }
-
-  static resetPasswordWithToken = async (
-    req: Request,
-    res: Response,
-  ): Promise<void> => {
-    const { token } = req.params
-    const { password } = req.body
-
-    try {
-      const user = await User.findOne({ where: { token } })
-
-      if (!user) {
-        res.status(401).json({ error: 'ユーザが見つかりません' })
-        return
-      }
-
-      // パスワードの再設定時も、ハッシュ化して登録する
-      user.password = await hashPassword(password)
-      // 認証コード用のtokenが正しいことが確認出来たら、tokenをnullにして無効にする
-      user.token = null
-      await user.save()
-
-      res.status(200).json({ message: 'パスワードが更新されました' })
-    } catch (error) {
-      res.status(500).json({ error: 'サーバーエラーが発生しました' })
-    }
-  }
-
-  static user = async (req: Request, res: Response): Promise<void> => {
-    res.json(req.user)
-  }
-  static updateUser = async (req: Request, res: Response): Promise<void> => {
-    res.json('認証されたユーザの更新APIテスト')
-  }
-
-  static updateCurrentUserPassword = async (
-    req: Request,
-    res: Response,
-  ): Promise<void> => {
-    const { current_password, password } = req.body
-    const { id } = req.user
-    const user = await User.findByPk(id)
-
-    //MEMO: IDから取得したユーザのパスワードと、current_passwordが一致するか確認
-    const isCheckPasswordCorrect = await checkPassword(
-      current_password,
-      user.password,
-    )
-    if (!isCheckPasswordCorrect) {
-      res.status(401).json({ error: '現在のパスワードが間違っています' })
-      return
-    }
-    //MEMO: 現在のパスワードの入力が正しい場合、再設定したパスワードを保存
-    user.password = await hashPassword(password)
-    await user.save()
-    res.status(200).json({ message: 'パスワードが更新されました' })
-  }
-
-  static checkPassword = async (req: Request, res: Response): Promise<void> => {
-    const { password } = req.body
-    const { id } = req.user
-
-    const user = await User.findByPk(id)
-
-    const isCorrectPassword = await checkPassword(password, user.password)
-    if (!isCorrectPassword) {
-      res.status(401).json({ error: 'パスワードが間違っています' })
-      return
-    }
-    res.status(201).json({ message: 'パスワードは正しいです' })
-  }
-}

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -85,124 +85,124 @@ export class AuthController {
         return // 関数を終了させる
       }
 
-      //     const isPasswordCorrect = await checkPassword(password, user.password)
-      //     // console.log('Password correct:', isPasswordCorrect);
-      //     if (!isPasswordCorrect) {
-      //       res.status(401).json({ error: 'パスワードが間違っています' })
-      //       return // 関数を終了させる
-      //     }
+      const isPasswordCorrect = await checkPassword(password, user.password)
+      // console.log('Password correct:', isPasswordCorrect);
+      if (!isPasswordCorrect) {
+        res.status(401).json({ error: 'パスワードが間違っています' })
+        return // 関数を終了させる
+      }
 
-      //     // JWTの生成
-      //     const token = generateJWT(user.id)
-      //     res.json({ message: 'アカウントのログインに成功しました！', token })
-      //   } catch (error) {
-      //     res.status(500).json({ error: 'サーバーエラーが発生しました' })
-      //   }
-      // }
-
-      // static forgotPassword = async (
-      //   req: Request,
-      //   res: Response,
-      // ): Promise<void> => {
-      //   const { email } = req.body
-      //   const user = await User.findOne({ where: { email } })
-      //   if (!user) {
-      //     res.status(401).json({ error: 'ユーザが見つかりません' })
-      //   }
-      //   user.token = generateToken()
-      //   await user.save()
-
-      //   await AuthEmail.sendResetPasswordEmail({
-      //     name: user.name,
-      //     email: user.email,
-      //     token: user.token,
-      //   })
-      //   res.status(201).json({
-      //     message: 'パスワードをリセットしました。メールを確認してください',
-      //     email: { to: user.email, token: user.token },
-      //   })
-      // }
-
-      // static validateToken = async (req: Request, res: Response): Promise<void> => {
-      //   //TODO: パスワードリセット時に生成したtokenが有効か確認する
-      //   const { token } = req.body
-      //   const user = await User.findOne({ where: { token } })
-      //   if (!user) {
-      //     res.status(401).json({ error: 'ユーザが見つかりません' })
-      //   }
-      //   res.status(200).json({
-      //     message: '有効なトークンです。新しいパスワードを設定してください。',
-      //   })
-      // }
-
-      // static resetPasswordWithToken = async (
-      //   req: Request,
-      //   res: Response,
-      // ): Promise<void> => {
-      //   const { token } = req.params
-      //   const { password } = req.body
-
-      //   try {
-      //     const user = await User.findOne({ where: { token } })
-
-      //     if (!user) {
-      //       res.status(401).json({ error: 'ユーザが見つかりません' })
-      //       return
-      //     }
-
-      //     // パスワードの再設定時も、ハッシュ化して登録する
-      //     user.password = await hashPassword(password)
-      //     // 認証コード用のtokenが正しいことが確認出来たら、tokenをnullにして無効にする
-      //     user.token = null
-      //     await user.save()
-
-      //     res.status(200).json({ message: 'パスワードが更新されました' })
-      //   } catch (error) {
-      //     res.status(500).json({ error: 'サーバーエラーが発生しました' })
-      //   }
-      // }
-
-      // static user = async (req: Request, res: Response): Promise<void> => {
-      //   res.json(req.user)
-      // }
-      // static updateUser = async (req: Request, res: Response): Promise<void> => {
-      //   res.json('認証されたユーザの更新APIテスト')
-      // }
-
-      // static updateCurrentUserPassword = async (
-      //   req: Request,
-      //   res: Response,
-      // ): Promise<void> => {
-      //   const { current_password, password } = req.body
-      //   const { id } = req.user
-      //   const user = await User.findByPk(id)
-
-      //   //MEMO: IDから取得したユーザのパスワードと、current_passwordが一致するか確認
-      //   const isCheckPasswordCorrect = await checkPassword(
-      //     current_password,
-      //     user.password,
-      //   )
-      //   if (!isCheckPasswordCorrect) {
-      //     res.status(401).json({ error: '現在のパスワードが間違っています' })
-      //     return
-      //   }
-      //   //MEMO: 現在のパスワードの入力が正しい場合、再設定したパスワードを保存
-      //   user.password = await hashPassword(password)
-      //   await user.save()
-      //   res.status(200).json({ message: 'パスワードが更新されました' })
-      // }
-
-      // static checkPassword = async (req: Request, res: Response): Promise<void> => {
-      //   const { password } = req.body
-      //   const { id } = req.user
-
-      //   const user = await User.findByPk(id)
-
-      //   const isCorrectPassword = await checkPassword(password, user.password)
-      //   if (!isCorrectPassword) {
-      //     res.status(401).json({ error: 'パスワードが間違っています' })
-      //     return
-      //   }
-      //   res.status(201).json({ message: 'パスワードは正しいです' })
-      // }
+      // JWTの生成
+      const token = generateJWT(user.id)
+      res.json({ message: 'アカウントのログインに成功しました！', token })
+    } catch (error) {
+      res.status(500).json({ error: 'サーバーエラーが発生しました' })
     }
+  }
+
+  // static forgotPassword = async (
+  //   req: Request,
+  //   res: Response,
+  // ): Promise<void> => {
+  //   const { email } = req.body
+  //   const user = await User.findOne({ where: { email } })
+  //   if (!user) {
+  //     res.status(401).json({ error: 'ユーザが見つかりません' })
+  //   }
+  //   user.token = generateToken()
+  //   await user.save()
+
+  //   await AuthEmail.sendResetPasswordEmail({
+  //     name: user.name,
+  //     email: user.email,
+  //     token: user.token,
+  //   })
+  //   res.status(201).json({
+  //     message: 'パスワードをリセットしました。メールを確認してください',
+  //     email: { to: user.email, token: user.token },
+  //   })
+  // }
+
+  // static validateToken = async (req: Request, res: Response): Promise<void> => {
+  //   //TODO: パスワードリセット時に生成したtokenが有効か確認する
+  //   const { token } = req.body
+  //   const user = await User.findOne({ where: { token } })
+  //   if (!user) {
+  //     res.status(401).json({ error: 'ユーザが見つかりません' })
+  //   }
+  //   res.status(200).json({
+  //     message: '有効なトークンです。新しいパスワードを設定してください。',
+  //   })
+  // }
+
+  // static resetPasswordWithToken = async (
+  //   req: Request,
+  //   res: Response,
+  // ): Promise<void> => {
+  //   const { token } = req.params
+  //   const { password } = req.body
+
+  //   try {
+  //     const user = await User.findOne({ where: { token } })
+
+  //     if (!user) {
+  //       res.status(401).json({ error: 'ユーザが見つかりません' })
+  //       return
+  //     }
+
+  //     // パスワードの再設定時も、ハッシュ化して登録する
+  //     user.password = await hashPassword(password)
+  //     // 認証コード用のtokenが正しいことが確認出来たら、tokenをnullにして無効にする
+  //     user.token = null
+  //     await user.save()
+
+  //     res.status(200).json({ message: 'パスワードが更新されました' })
+  //   } catch (error) {
+  //     res.status(500).json({ error: 'サーバーエラーが発生しました' })
+  //   }
+  // }
+
+  // static user = async (req: Request, res: Response): Promise<void> => {
+  //   res.json(req.user)
+  // }
+  // static updateUser = async (req: Request, res: Response): Promise<void> => {
+  //   res.json('認証されたユーザの更新APIテスト')
+  // }
+
+  // static updateCurrentUserPassword = async (
+  //   req: Request,
+  //   res: Response,
+  // ): Promise<void> => {
+  //   const { current_password, password } = req.body
+  //   const { id } = req.user
+  //   const user = await User.findByPk(id)
+
+  //   //MEMO: IDから取得したユーザのパスワードと、current_passwordが一致するか確認
+  //   const isCheckPasswordCorrect = await checkPassword(
+  //     current_password,
+  //     user.password,
+  //   )
+  //   if (!isCheckPasswordCorrect) {
+  //     res.status(401).json({ error: '現在のパスワードが間違っています' })
+  //     return
+  //   }
+  //   //MEMO: 現在のパスワードの入力が正しい場合、再設定したパスワードを保存
+  //   user.password = await hashPassword(password)
+  //   await user.save()
+  //   res.status(200).json({ message: 'パスワードが更新されました' })
+  // }
+
+  // static checkPassword = async (req: Request, res: Response): Promise<void> => {
+  //   const { password } = req.body
+  //   const { id } = req.user
+
+  //   const user = await User.findByPk(id)
+
+  //   const isCorrectPassword = await checkPassword(password, user.password)
+  //   if (!isCorrectPassword) {
+  //     res.status(401).json({ error: 'パスワードが間違っています' })
+  //     return
+  //   }
+  //   res.status(201).json({ message: 'パスワードは正しいです' })
+  // }
+}

--- a/backend/src/routes/authRouter.ts
+++ b/backend/src/routes/authRouter.ts
@@ -50,82 +50,82 @@ router.post(
   AuthController.login,
 )
 
-router.post(
-  '/forgot-password',
-  body('email')
-    .isEmail()
-    .withMessage('メールアドレスは有効な形式ではありません'),
-  handleInputErrors,
-  AuthController.forgotPassword,
-)
+// router.post(
+//   '/forgot-password',
+//   body('email')
+//     .isEmail()
+//     .withMessage('メールアドレスは有効な形式ではありません'),
+//   handleInputErrors,
+//   AuthController.forgotPassword,
+// )
 
-router.post(
-  '/validate-token',
-  body('token')
-    .notEmpty()
-    .withMessage('認証コードは必須です')
-    .bail()
-    .isLength({ min: 6, max: 6 })
-    .withMessage('トークンが無効です'),
-  handleInputErrors,
-  AuthController.validateToken,
-)
+// router.post(
+//   '/validate-token',
+//   body('token')
+//     .notEmpty()
+//     .withMessage('認証コードは必須です')
+//     .bail()
+//     .isLength({ min: 6, max: 6 })
+//     .withMessage('トークンが無効です'),
+//   handleInputErrors,
+//   AuthController.validateToken,
+// )
 
-router.post(
-  '/reset-password/:token',
-  // MEMO: paramを使用
-  param('token')
-    .notEmpty()
-    .withMessage('認証コードは必須です')
-    .bail()
-    .isLength({ min: 6, max: 6 })
-    .withMessage('トークンが無効です'),
-  body('password')
-    .notEmpty()
-    .withMessage('パスワードは必須です')
-    .isLength({ min: 8 })
-    .withMessage('パスワードは8文字以上です'),
-  handleInputErrors,
-  AuthController.resetPasswordWithToken,
-)
+// router.post(
+//   '/reset-password/:token',
+//   // MEMO: paramを使用
+//   param('token')
+//     .notEmpty()
+//     .withMessage('認証コードは必須です')
+//     .bail()
+//     .isLength({ min: 6, max: 6 })
+//     .withMessage('トークンが無効です'),
+//   body('password')
+//     .notEmpty()
+//     .withMessage('パスワードは必須です')
+//     .isLength({ min: 8 })
+//     .withMessage('パスワードは8文字以上です'),
+//   handleInputErrors,
+//   AuthController.resetPasswordWithToken,
+// )
 
-router.get(
-  '/user',
-  authenticate,
-  // handleInputErrors,
-  AuthController.user,
-)
+// router.get(
+//   '/user',
+//   authenticate,
+//   // handleInputErrors,
+//   AuthController.user,
+// )
 
-router.put(
-  '/user',
-  authenticate,
-  // handleInputErrors,
-  AuthController.updateUser,
-)
+// router.put(
+//   '/user',
+//   authenticate,
+//   // handleInputErrors,
+//   AuthController.updateUser,
+// )
 
-router.post(
-  '/update-password',
-  authenticate,
-  body('current_password')
-    .notEmpty()
-    .withMessage('現在のパスワードは必須です')
-    .isLength({ min: 8 })
-    .withMessage('現在のパスワードは8文字以上です'),
-  body('password')
-    .notEmpty()
-    .withMessage('再設定するパスワードは必須です')
-    .isLength({ min: 8 })
-    .withMessage('再設定するパスワードは8文字以上です'),
-  handleInputErrors,
-  AuthController.updateCurrentUserPassword,
-)
+// router.post(
+//   '/update-password',
+//   authenticate,
+//   body('current_password')
+//     .notEmpty()
+//     .withMessage('現在のパスワードは必須です')
+//     .isLength({ min: 8 })
+//     .withMessage('現在のパスワードは8文字以上です'),
+//   body('password')
+//     .notEmpty()
+//     .withMessage('再設定するパスワードは必須です')
+//     .isLength({ min: 8 })
+//     .withMessage('再設定するパスワードは8文字以上です'),
+//   handleInputErrors,
+//   AuthController.updateCurrentUserPassword,
+// )
 
-router.post(
-  '/check-password',
-  authenticate,
-  body('password').notEmpty().withMessage('パスワードは必須です'),
-  handleInputErrors,
-  AuthController.checkPassword,
-)
+// router.post(
+//   '/check-password',
+//   authenticate,
+//   body('password').notEmpty().withMessage('パスワードは必須です'),
+//   handleInputErrors,
+//   AuthController.checkPassword,
+// )
 
 export default router

--- a/backend/src/routes/authRouter.ts
+++ b/backend/src/routes/authRouter.ts
@@ -50,82 +50,82 @@ router.post(
   AuthController.login,
 )
 
-// router.post(
-//   '/forgot-password',
-//   body('email')
-//     .isEmail()
-//     .withMessage('メールアドレスは有効な形式ではありません'),
-//   handleInputErrors,
-//   AuthController.forgotPassword,
-// )
+router.post(
+  '/forgot-password',
+  body('email')
+    .isEmail()
+    .withMessage('メールアドレスは有効な形式ではありません'),
+  handleInputErrors,
+  AuthController.forgotPassword,
+)
 
-// router.post(
-//   '/validate-token',
-//   body('token')
-//     .notEmpty()
-//     .withMessage('認証コードは必須です')
-//     .bail()
-//     .isLength({ min: 6, max: 6 })
-//     .withMessage('トークンが無効です'),
-//   handleInputErrors,
-//   AuthController.validateToken,
-// )
+router.post(
+  '/validate-token',
+  body('token')
+    .notEmpty()
+    .withMessage('認証コードは必須です')
+    .bail()
+    .isLength({ min: 6, max: 6 })
+    .withMessage('トークンが無効です'),
+  handleInputErrors,
+  AuthController.validateToken,
+)
 
-// router.post(
-//   '/reset-password/:token',
-//   // MEMO: paramを使用
-//   param('token')
-//     .notEmpty()
-//     .withMessage('認証コードは必須です')
-//     .bail()
-//     .isLength({ min: 6, max: 6 })
-//     .withMessage('トークンが無効です'),
-//   body('password')
-//     .notEmpty()
-//     .withMessage('パスワードは必須です')
-//     .isLength({ min: 8 })
-//     .withMessage('パスワードは8文字以上です'),
-//   handleInputErrors,
-//   AuthController.resetPasswordWithToken,
-// )
+router.post(
+  '/reset-password/:token',
+  // MEMO: paramを使用
+  param('token')
+    .notEmpty()
+    .withMessage('認証コードは必須です')
+    .bail()
+    .isLength({ min: 6, max: 6 })
+    .withMessage('トークンが無効です'),
+  body('password')
+    .notEmpty()
+    .withMessage('パスワードは必須です')
+    .isLength({ min: 8 })
+    .withMessage('パスワードは8文字以上です'),
+  handleInputErrors,
+  AuthController.resetPasswordWithToken,
+)
 
-// router.get(
-//   '/user',
-//   authenticate,
-//   // handleInputErrors,
-//   AuthController.user,
-// )
+router.get(
+  '/user',
+  authenticate,
+  // handleInputErrors,
+  AuthController.user,
+)
 
-// router.put(
-//   '/user',
-//   authenticate,
-//   // handleInputErrors,
-//   AuthController.updateUser,
-// )
+router.put(
+  '/user',
+  authenticate,
+  // handleInputErrors,
+  AuthController.updateUser,
+)
 
-// router.post(
-//   '/update-password',
-//   authenticate,
-//   body('current_password')
-//     .notEmpty()
-//     .withMessage('現在のパスワードは必須です')
-//     .isLength({ min: 8 })
-//     .withMessage('現在のパスワードは8文字以上です'),
-//   body('password')
-//     .notEmpty()
-//     .withMessage('再設定するパスワードは必須です')
-//     .isLength({ min: 8 })
-//     .withMessage('再設定するパスワードは8文字以上です'),
-//   handleInputErrors,
-//   AuthController.updateCurrentUserPassword,
-// )
+router.post(
+  '/update-password',
+  authenticate,
+  body('current_password')
+    .notEmpty()
+    .withMessage('現在のパスワードは必須です')
+    .isLength({ min: 8 })
+    .withMessage('現在のパスワードは8文字以上です'),
+  body('password')
+    .notEmpty()
+    .withMessage('再設定するパスワードは必須です')
+    .isLength({ min: 8 })
+    .withMessage('再設定するパスワードは8文字以上です'),
+  handleInputErrors,
+  AuthController.updateCurrentUserPassword,
+)
 
-// router.post(
-//   '/check-password',
-//   authenticate,
-//   body('password').notEmpty().withMessage('パスワードは必須です'),
-//   handleInputErrors,
-//   AuthController.checkPassword,
-// )
+router.post(
+  '/check-password',
+  authenticate,
+  body('password').notEmpty().withMessage('パスワードは必須です'),
+  handleInputErrors,
+  AuthController.checkPassword,
+)
 
 export default router

--- a/backend/src/tests/unit/controllers/AuthController.test.ts
+++ b/backend/src/tests/unit/controllers/AuthController.test.ts
@@ -1,0 +1,100 @@
+import { AuthEmail } from '../../../emails/AuthEmail';
+import User from '../../../models/User';
+import { hashPassword } from '../../../utils/auth';
+import { generateToken } from '../../../utils/token';
+import { AuthController } from './../../../controllers/AuthController';
+import { createRequest, createResponse } from "node-mocks-http";
+
+jest.mock('../../../models/User')
+jest.mock('../../../utils/auth.ts')
+jest.mock('../../../utils/token.ts')
+jest.mock('../../../utils/jwt.ts')
+
+describe('AuthController.createAccount', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('ユーザ登録時に、すでにメールアドレスが登録されていた場合', async () => {
+
+    (User.findOne as jest.Mock).mockResolvedValue(true)
+
+    const req = createRequest({
+      method: 'POST',
+      url: '/api/auth/create-account',
+      body: {
+        email: "test@test.com",
+        password: "testpassword"
+      }
+    })
+    const res = createResponse()
+
+    await AuthController.createAccount(req, res)
+
+    const data = res._getJSONData()
+    expect(res.statusCode).toBe(409)
+    expect(data).toStrictEqual({ error: 'そのメールアドレスは既に登録されています。' })
+    expect(User.findOne).toHaveBeenCalled()
+    expect(User.findOne).toHaveBeenCalledTimes(1)
+  })
+  it('ユーザ登録成功時のテスト', async () => {
+    (User.findOne as jest.Mock).mockResolvedValue(null)
+    const req = createRequest({
+      method: 'POST',
+      url: '/api/auth/create-account',
+      body: {
+        email: "test@test.com",
+        password: "testpassword",
+        name: "Test Name"
+      }
+    })
+    const res = createResponse()
+    const mockUser = { ...req.body, save: jest.fn() };
+
+    (User.create as jest.Mock).mockResolvedValue(mockUser);
+    (hashPassword as jest.Mock).mockReturnValue('alsjalslj./fh');
+    (generateToken as jest.Mock).mockReturnValue('123456');
+    jest.spyOn(AuthEmail, "sendConfirmationEmail").mockImplementation(() => Promise.resolve());
+
+    await AuthController.createAccount(req, res)
+
+    expect(User.create).toHaveBeenCalledWith(req.body)
+    expect(User.create).toHaveBeenCalledTimes(1)
+    expect(mockUser.save).toHaveBeenCalled()
+    expect(mockUser.password).toBe('alsjalslj./fh')
+    expect(mockUser.token).toBe('123456')
+    expect(AuthEmail.sendConfirmationEmail).toHaveBeenCalledWith({
+      name: req.body.name,
+      email: req.body.email,
+      token: '123456'
+    })
+    expect(AuthEmail.sendConfirmationEmail).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(201)
+  })
+
+
+  it('ユーザ登録時、何らかの不具合があったときのテスト', async () => {
+    const mockUser = {
+      save: jest.fn(),
+    };
+    (User.create as jest.Mock).mockRejectedValue(new Error())
+    const req = createRequest({
+      method: 'POST',
+      url: '/api/auth/create-account',
+      body: {
+        email: "test@test.com",
+        password: "testpassword",
+        name: "Test Name"
+      }
+    })
+    const res = createResponse()
+
+    await AuthController.createAccount(req, res)
+
+    const data = res._getJSONData()
+
+    expect(mockUser.save).not.toHaveBeenCalled()
+    expect(data).toStrictEqual({ error: 'ユーザ作成中にエラーが発生しました' })
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/backend/src/tests/unit/middleware/expense.test.ts
+++ b/backend/src/tests/unit/middleware/expense.test.ts
@@ -18,7 +18,7 @@ describe('middleware - validateExpenseExists', () => {
   })
   it('支出が存在しない場合のミドルウェアテスト', async () => {
     (Expense.findByPk as jest.Mock).mockResolvedValue(undefined);
-    console.log('支出が存在しない場合のミドルウェアテストlog');
+    // console.log('支出が存在しない場合のミドルウェアテストlog');
     const req = createRequest({
       params: {
         expenseId: 1
@@ -75,7 +75,7 @@ describe('middleware - hasAccess', () => {
   })
 
   it('アクセス権がない場合のテスト', () => {
-    // (Expense.findByPk as jest.Mock).mockRejectedValue(new Error)
+    (Expense.findByPk as jest.Mock).mockRejectedValue(new Error)
     const req = createRequest({
       method: 'POST',
       url: '/api/budgets/:budgetId/expenses',


### PR DESCRIPTION
# 概要
ブランチ名  
`feature-18-unit-test-for-create-account`

AuthController.createAccountに関する単体テストを実装し、動作確認を行いました。

## 変更内容

1. **AuthController.createAccountのテスト追加**:
   - 新規アドレスでの登録時、以下の動作が確認できるテストケースを追加:
     - 入力したパスワードや生成されたトークン、メールで送信されたユーザ名、メールアドレス、トークンが正しく取得される
     - ステータスコード 201 が返される
     - `save` や `create` メソッドが呼ばれること

   - すでにアプリに登録されているメールアドレスを使ってユーザ登録しようとした場合、以下が確認できるテストケースを追加:
     - エラーメッセージ "そのメールアドレスは既に登録されています" が返される
     - ステータスコード 409 が返される
  
- 何らかの不具合でアカウント作成ができなかった場合、以下が確認できるテストケースを追加:
     - エラーメッセージ "ユーザ作成中にエラーが発生しました" が返される
     - ステータスコード 500 が返される
     - saveメソッドが呼ばれない


## 動作要件
追加したテストが正しく動作することを確認:
- `yarn test` コマンドを実行し、すべてのテストが正常にパスすること。
- 各テストケースが期待通りの結果を返すこと。

## 影響範囲
- **テスト環境**:
  - ユニットテストの追加により、テストカバレッジが向上する。
  - テスト環境の設定に変更はない。

- **コードベース**:
  - `BudgetController`のテストコードが追加される。

## 補足事項
1. **テストとデバッグ**:
   - 新しいテストケースに対して十分にテストを行い、予期しないバグがないことを確認。
   - エラーハンドリングとログ出力を確認し、問題が発生した場合に迅速に対応できるようにする。

2. **ドキュメント更新**:
   - 新しいテストケースに関するドキュメントを更新し、開発チームやユーザーに共有する。

3. **テストカバレッジ**:
   - テストカバレッジレポートを生成し、コードのカバレッジを確認する。
   - 必要に応じて追加のテストケースを作成し、テストカバレッジを向上させる。
