### PR TITLE
Feature 28 create auth page

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -3,10 +3,10 @@ module.exports = {
   testEnvironment: 'node',
   testTimeout: 30000,
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '^.+\\.tsx?$': 'ts-jest',
   },
   collectCoverage: true,
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'html'],
   verbose: true,
-};
+}

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express'
+import { AuthEmail } from '../emails/AuthEmail'
 import User from '../models/User'
 import { hashPassword } from '../utils/auth'
 import { generateJWT } from '../utils/jwt'
@@ -28,6 +29,12 @@ export class AuthController {
         ...req.body,
         // password: hashedPassword,  <- この行を削除
         token: token,
+      })
+
+      await AuthEmail.sendConfirmationEmail({
+        name: user.name,
+        email: user.email,
+        token: user.token,
       })
 
       // 残りの処理はそのまま...
@@ -143,11 +150,11 @@ export class AuthController {
     await User.findByIdAndUpdate(user._id, { token })
 
     // MEMO: 一時退避
-    // await AuthEmail.sendResetPasswordEmail({
-    //   name: user.name,
-    //   email: user.email,
-    //   token: user.token,
-    // })
+    await AuthEmail.sendResetPasswordEmail({
+      name: user.name,
+      email: user.email,
+      token: user.token,
+    })
     res.status(201).json({
       message: 'パスワードをリセットしました。メールを確認してください',
       email: { to: user.email, token },

--- a/backend/src/data/index.ts
+++ b/backend/src/data/index.ts
@@ -9,16 +9,15 @@ const clearData = async () => {
     //MEMO: 正常終了
     exit(0)
   } catch (error) {
-    console.log(error, 'DBのクリアに失敗しました');
+    console.log(error, 'DBのクリアに失敗しました')
     //MEMO: 異常終了
     exit(1)
   }
 }
 
 if (process.argv[2] === '--clear') {
-  clearData();
+  clearData()
 }
-
 
 //MEMO: package.json
 // "pretest": "ts-node ./src/data --clear"

--- a/backend/src/emails/AuthEmail.ts
+++ b/backend/src/emails/AuthEmail.ts
@@ -14,10 +14,12 @@ export class AuthEmail {
         to: user.email,
         subject: 'CashTracker - アカウントの確認',
         html: `<p>こんにちは: ${user.name}さん！</p>
-        　　　　<p>CashTrackerにアカウントを作成しました。もう少しで完了です。</p>
-                <p>次のリンクをクリックしてください:</p>
-                <a href="${process.env.FRONTEND_URL}/auth/confirm-account">アカウントを確認する</a>
-                <p>この認証コードを入力してください: <b>${user.token}</b></p>`,
+              <p>CashTrackerにアカウントを作成しました。もう少しで完了です。</p>
+              <p>次のリンクをクリックしてください:</p>
+              <p><a href="${process.env.FRONTEND_URL}/auth/confirm-account" target="_blank" rel="noopener noreferrer">アカウントを確認する</a></p>
+              <p>リンクが機能しない場合は、以下のURLをブラウザに直接コピー＆ペーストしてください：</p>
+              <p>${process.env.FRONTEND_URL}/auth/confirm-account</p>
+              <p>この認証コードを入力してください: <b>${user.token}</b></p>`,
       })
 
       // メール送信の結果をログに出力

--- a/backend/src/emails/AuthEmail.ts
+++ b/backend/src/emails/AuthEmail.ts
@@ -42,7 +42,7 @@ export class AuthEmail {
         html: `<p>こんにちは: ${user.name}さん！パスワードのリセットを受け付けました</p>
         　　　　<p>パスワードの再設定用の認証コードを共有します。もう少しで設定完了です。</p>
                 <p>次のリンクをクリックしてパスワードの再設定を行ってください:</p>
-                <a href="${process.env.FRONTEND_URL}/auth/forgot-password">パスワードの再設定を行う</a>
+                <a href="${process.env.FRONTEND_URL}/auth/forgot-password" target="_blank" rel="noopener noreferrer">パスワードの再設定を行う</a>
                 <p>この認証コードを入力してください: <b>${user.token}</b></p>`,
       })
       // メール送信の結果をログに出力

--- a/backend/src/tests/integration/app.test.ts
+++ b/backend/src/tests/integration/app.test.ts
@@ -1,4 +1,4 @@
-import { Accessor } from './../../../node_modules/@babel/types/lib/index-legacy.d';
+import { Accessor } from './../../../node_modules/@babel/types/lib/index-legacy.d'
 import request from 'supertest'
 import server, { connectDB } from '../../server'
 import { AuthController } from '../../controllers/AuthController'
@@ -6,7 +6,6 @@ import User from '../../models/User'
 import * as jwtUtils from '../../utils/jwt'
 import * as authUtils from '../../utils/token'
 import { generateToken } from '../../utils/token'
-
 
 describe('Authentication: create account', () => {
   it('入力フォームが空だった時のバリデーションエラーのテストケース', async () => {
@@ -103,7 +102,6 @@ describe('Authentication: create account', () => {
 })
 
 describe('Authentication: confirm account', () => {
-
   it('tokenが空で送信された場合のユーザ確認時のバリデーションエラーのテストケース', async () => {
     // console.log('tokenが空で送信された場合のユーザ確認時のバリデーションエラー');
     // const userData = {
@@ -117,7 +115,7 @@ describe('Authentication: confirm account', () => {
     const confirmAccountMock = jest.spyOn(AuthController, 'confirmAccount')
 
     expect(response.statusCode).toBe(400)
-    expect(response.body.errors[0].msg).toEqual('認証コードは必須です');
+    expect(response.body.errors[0].msg).toEqual('認証コードは必須です')
     expect(confirmAccountMock).not.toHaveBeenCalled()
     expect(response.body.errors[0]).toHaveProperty('msg')
   })
@@ -125,18 +123,17 @@ describe('Authentication: confirm account', () => {
   it('tokenが6文字でない場合のユーザ確認時のバリデーションエラーのテストケース', async () => {
     // console.log('tokenが無効な場合のユーザ確認時のバリデーションエラー');
     const userData = {
-      token: '3493'
+      token: '3493',
     }
     const response = await request(server)
       .post('/api/auth/confirm-account')
       .send(userData)
 
-
     // console.log(response.body.errors[0].msg, 'tokenが無効の場合')
     const confirmAccountMock = jest.spyOn(AuthController, 'confirmAccount')
 
     expect(response.statusCode).toBe(400)
-    expect(response.body.errors[0].msg).toEqual('トークンが無効です');
+    expect(response.body.errors[0].msg).toEqual('トークンが無効です')
     expect(confirmAccountMock).not.toHaveBeenCalled()
     expect(response.body.errors[0]).toHaveProperty('msg')
   })
@@ -145,10 +142,9 @@ describe('Authentication: confirm account', () => {
     const response = await request(server)
       .post('/api/auth/confirm-account')
       .send({
-        token: "123456"
+        token: '123456',
       })
     // console.log(response.body, 'tokenが無効な場合の結果');
-
 
     expect(response.status).toBe(401)
     // expect(response).toHaveProperty('body')
@@ -178,9 +174,7 @@ describe('Authentication: user authentication', () => {
   })
   it('空のフォームが入力された場合のバリデーションエラーのテストケース', async () => {
     // console.log('空のフォームが送信されました');
-    const response = await request(server)
-      .post('/api/auth/login')
-      .send({})
+    const response = await request(server).post('/api/auth/login').send({})
     const loginMock = jest.spyOn(AuthController, 'login')
 
     expect(response.statusCode).toBe(400)
@@ -194,13 +188,15 @@ describe('Authentication: user authentication', () => {
     }
     const response = await request(server)
       .post('/api/auth/login')
-      .send(userData);
+      .send(userData)
 
-    const loginMock = jest.spyOn(AuthController, 'login');
+    const loginMock = jest.spyOn(AuthController, 'login')
 
-    expect(response.statusCode).toBe(400);
-    expect(response.body.errors[0].msg).toEqual('メールアドレスは有効な形式ではありません')
-    expect(loginMock).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(400)
+    expect(response.body.errors[0].msg).toEqual(
+      'メールアドレスは有効な形式ではありません',
+    )
+    expect(loginMock).not.toHaveBeenCalled()
   })
   it('ユーザが存在しない場合のテストケース', async () => {
     // console.log('ユーザが存在しません');
@@ -212,25 +208,22 @@ describe('Authentication: user authentication', () => {
       .post('/api/auth/login')
       .send(userData)
 
-    const loginMock = jest.spyOn(AuthController, 'login');
+    const loginMock = jest.spyOn(AuthController, 'login')
 
     // (User.findOne as jest.Mock).mockResolvedValue(undefined);
 
     // console.log(response.body, 'ユーザが存在しない場合のレスポンスデータ');
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(401)
     expect(loginMock).not.toHaveBeenCalled()
-
-
   })
   it('アカウントがまだ有効化されていない場合のテストケース', async () => {
     // console.log('アカウントがまだ有効化されていません');
-    (jest.spyOn(User, 'findOne') as jest.Mock)
-      .mockResolvedValue({
-        id: 500,
-        confirmed: false,
-        password: "hashed_password"
-      })
+    ;(jest.spyOn(User, 'findOne') as jest.Mock).mockResolvedValue({
+      id: 500,
+      confirmed: false,
+      password: 'hashed_password',
+    })
     const userData = {
       email: 'yamada@example.com',
       password: 'password',
@@ -239,21 +232,26 @@ describe('Authentication: user authentication', () => {
       .post('/api/auth/login')
       .send(userData)
 
-    const loginMock = jest.spyOn(AuthController, 'login');
+    const loginMock = jest.spyOn(AuthController, 'login')
 
     expect(response.statusCode).toBe(401)
-    expect(response.body.error).toStrictEqual('アカウントがまだ有効化されていません。メールに送信された認証コードを使用してアカウントを有効化してください')
+    expect(response.body.error).toStrictEqual(
+      'アカウントがまだ有効化されていません。メールに送信された認証コードを使用してアカウントを有効化してください',
+    )
     expect(loginMock).not.toHaveBeenCalled()
   })
   it('パスワードが間違えている場合のテストケース', async () => {
     // console.log('パスワードは8文字以上で入力してください');
-    const findOne = (jest.spyOn(User, 'findOne') as jest.Mock)
-      .mockResolvedValue({
-        id: 500,
-        confirmed: true,
-        password: "hashed_password"
-      })
-    const checkPassword = jest.spyOn(authUtils, 'checkPassword').mockResolvedValue(undefined);
+    const findOne = (
+      jest.spyOn(User, 'findOne') as jest.Mock
+    ).mockResolvedValue({
+      id: 500,
+      confirmed: true,
+      password: 'hashed_password',
+    })
+    const checkPassword = jest
+      .spyOn(authUtils, 'checkPassword')
+      .mockResolvedValue(undefined)
     const userData = {
       email: 'yamada@example.com',
       password: 'wrong_password',
@@ -263,41 +261,49 @@ describe('Authentication: user authentication', () => {
       .post('/api/auth/login')
       .send(userData)
 
-    const loginMock = jest.spyOn(AuthController, 'login');
+    const loginMock = jest.spyOn(AuthController, 'login')
     // console.log(response.body, 'パスワードが間違えている場合のレスポンスデータ');
 
-    expect(response.statusCode).toBe(401);
-    expect(loginMock).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(401)
+    expect(loginMock).not.toHaveBeenCalled()
     expect(response.body.error).toStrictEqual('パスワードが間違っています')
-    expect(findOne).toHaveBeenCalledTimes(1);
+    expect(findOne).toHaveBeenCalledTimes(1)
     expect(checkPassword).toHaveBeenCalledTimes(1)
   })
   it('ログインの成功と、JWTの検証テスト', async () => {
     // console.log('ログインに成功しました/JWTが発行されました');
-    const findOne = (jest.spyOn(User, 'findOne') as jest.Mock)
-      .mockResolvedValue({
-        id: 500,
-        confirmed: true,
-        password: "hashed_password"
-      })
-    const checkPassword = jest.spyOn(authUtils, 'checkPassword').mockResolvedValue(true)
-    const generateJWT = jest.spyOn(jwtUtils, 'generateJWT').mockReturnValue('test_jwt')
+    const findOne = (
+      jest.spyOn(User, 'findOne') as jest.Mock
+    ).mockResolvedValue({
+      id: 500,
+      confirmed: true,
+      password: 'hashed_password',
+    })
+    const checkPassword = jest
+      .spyOn(authUtils, 'checkPassword')
+      .mockResolvedValue(true)
+    const generateJWT = jest
+      .spyOn(jwtUtils, 'generateJWT')
+      .mockReturnValue('test_jwt')
     const userData = {
       email: 'yamada@example.com',
       password: 'pure_password',
     }
-    const response = request(server)
-      .post('/api/auth/login')
-      .send(userData);
+    const response = request(server).post('/api/auth/login').send(userData)
 
     // console.log((await response).body, 'ログイン成功時のレスポンスデータ');
 
-    expect((await response).body.message).toEqual('アカウントのログインに成功しました！')
+    expect((await response).body.message).toEqual(
+      'アカウントのログインに成功しました！',
+    )
     expect((await response).body.token).toEqual('test_jwt')
 
     expect(checkPassword).toHaveBeenCalled()
     expect(checkPassword).toHaveBeenCalledTimes(1)
-    expect(checkPassword).toHaveBeenCalledWith('pure_password', 'hashed_password')
+    expect(checkPassword).toHaveBeenCalledWith(
+      'pure_password',
+      'hashed_password',
+    )
 
     expect(generateJWT).toHaveBeenCalled()
     expect(generateJWT).toHaveBeenCalledTimes(1)
@@ -309,28 +315,25 @@ describe('Authentication: user authentication', () => {
 let jwt: string
 
 async function authenticateUser() {
-  const response = await request(server)
-    .post('/api/auth/login')
-    .send({
-      email: 'test@example.com',
-      password: 'password'
-    })
-  jwt = response.body.token;
+  const response = await request(server).post('/api/auth/login').send({
+    email: 'test@example.com',
+    password: 'password',
+  })
+  jwt = response.body.token
 
-  expect(response.status).toBe(200);
+  expect(response.status).toBe(200)
   expect(response.body.message).toEqual('アカウントのログインに成功しました！')
 }
 
 describe('GET /api/budgets', () => {
   beforeAll(() => {
-    jest.restoreAllMocks();
+    jest.restoreAllMocks()
   })
   beforeAll(async () => {
     await authenticateUser()
   })
   it('JWT認証されていないユーザが予算データにアクセスしようとしたときのテスト', async () => {
-    const response = await request(server)
-      .get('/api/budgets')
+    const response = await request(server).get('/api/budgets')
 
     expect(response.status).toBe(401)
     expect(response.body.error).toBe('認証が必要です')
@@ -358,11 +361,10 @@ describe('GET /api/budgets', () => {
 
 describe('POST /api/budgets', () => {
   beforeAll(async () => {
-    await authenticateUser();
+    await authenticateUser()
   })
   it('JWT認証されていないユーザが、予算作成をしようとしたときの結合テストケース', async () => {
-    const response = await request(server)
-      .post('/api/budgets')
+    const response = await request(server).post('/api/budgets')
 
     expect(response.status).toBe(401)
     expect(response.body.error).toBe('認証が必要です')
@@ -388,9 +390,9 @@ describe('POST /api/budgets', () => {
       expect.arrayContaining([
         expect.objectContaining({ msg: '予算タイトルは必須です' }),
         expect.objectContaining({ msg: '予算金額は必須です' }),
-        expect.objectContaining({ msg: '予算金額の値が無効です' })
-      ])
-    );
+        expect.objectContaining({ msg: '予算金額の値が無効です' }),
+      ]),
+    )
 
     expect(response.status).toBe(400)
   })
@@ -400,8 +402,8 @@ describe('POST /api/budgets', () => {
       .post('/api/budgets')
       .auth(jwt, { type: 'bearer' })
       .send({
-        'name': '食費',
-        'amount': 30000
+        name: '食費',
+        amount: 30000,
       })
 
     expect(response.status).not.toBe(401)
@@ -413,11 +415,10 @@ describe('POST /api/budgets', () => {
 
 describe('GET /api/budgets/:id', () => {
   beforeAll(async () => {
-    await authenticateUser();
+    await authenticateUser()
   })
   it('JWT認証されていないユーザが、予算データの取得をしようとしたときの結合テストケース', async () => {
-    const response = await request(server)
-      .get('/api/budgets/1')
+    const response = await request(server).get('/api/budgets/1')
 
     expect(response.status).toBe(401)
     expect(response.body.error).toBe('認証が必要です')
@@ -453,8 +454,7 @@ describe('GET /api/budgets/:id', () => {
 
 describe('PUT /api/budgets/:id', () => {
   it('JWT認証されていないユーザが、予算データの更新をしようとしたときの結合テストケース', async () => {
-    const response = await request(server)
-      .put('/api/budgets/1')
+    const response = await request(server).put('/api/budgets/1')
 
     expect(response.status).toBe(401)
     expect(response.body.error).toBe('認証が必要です')
@@ -488,9 +488,9 @@ describe('PUT /api/budgets/:id', () => {
       expect.arrayContaining([
         expect.objectContaining({ msg: '予算タイトルは必須です' }),
         expect.objectContaining({ msg: '予算金額は必須です' }),
-        expect.objectContaining({ msg: '予算金額の値が無効です' })
-      ])
-    );
+        expect.objectContaining({ msg: '予算金額の値が無効です' }),
+      ]),
+    )
 
     expect(response.status).toBe(400)
   })
@@ -499,8 +499,8 @@ describe('PUT /api/budgets/:id', () => {
       .put('/api/budgets/1')
       .auth(jwt, { type: 'bearer' })
       .send({
-        'name': '光熱費',
-        'amount': 15000
+        name: '光熱費',
+        amount: 15000,
       })
 
     expect(response.status).not.toBe(401)
@@ -512,8 +512,7 @@ describe('PUT /api/budgets/:id', () => {
 
 describe('DELETE /api/budgets/:id', () => {
   it('JWT認証されていないユーザが、予算データの削除をしようとしたときの結合テストケース', async () => {
-    const response = await request(server)
-      .delete('/api/budgets/1')
+    const response = await request(server).delete('/api/budgets/1')
 
     expect(response.status).toBe(401)
     expect(response.body.error).toBe('認証が必要です')

--- a/backend/src/tests/unit/controllers/AuthController.test.ts
+++ b/backend/src/tests/unit/controllers/AuthController.test.ts
@@ -17,7 +17,7 @@ describe('AuthController.createAccount', () => {
   })
 
   it('ユーザ登録時に、すでにメールアドレスが登録されていた場合', async () => {
-    ; (User.findOne as jest.Mock).mockResolvedValue(true)
+    ;(User.findOne as jest.Mock).mockResolvedValue(true)
 
     const req = createRequest({
       method: 'POST',
@@ -40,7 +40,7 @@ describe('AuthController.createAccount', () => {
     expect(User.findOne).toHaveBeenCalledTimes(1)
   })
   it('ユーザ登録成功時のテスト', async () => {
-    ; (User.findOne as jest.Mock).mockResolvedValue(null)
+    ;(User.findOne as jest.Mock).mockResolvedValue(null)
     const req = createRequest({
       method: 'POST',
       url: '/api/auth/create-account',
@@ -53,9 +53,9 @@ describe('AuthController.createAccount', () => {
     const res = createResponse()
     const mockUser = { ...req.body, save: jest.fn() }
 
-      ; (User.create as jest.Mock).mockResolvedValue(mockUser)
-      ; (hashPassword as jest.Mock).mockReturnValue('alsjalslj./fh')
-      ; (generateToken as jest.Mock).mockReturnValue('123456')
+    ;(User.create as jest.Mock).mockResolvedValue(mockUser)
+    ;(hashPassword as jest.Mock).mockReturnValue('alsjalslj./fh')
+    ;(generateToken as jest.Mock).mockReturnValue('123456')
     jest
       .spyOn(AuthEmail, 'sendConfirmationEmail')
       .mockImplementation(() => Promise.resolve())
@@ -80,7 +80,7 @@ describe('AuthController.createAccount', () => {
     const mockUser = {
       save: jest.fn(),
     }
-      ; (User.create as jest.Mock).mockRejectedValue(new Error())
+    ;(User.create as jest.Mock).mockRejectedValue(new Error())
     const req = createRequest({
       method: 'POST',
       url: '/api/auth/create-account',
@@ -120,7 +120,7 @@ describe('AuthController.login', () => {
       },
     })
 
-      ; (User.findOne as jest.Mock).mockResolvedValue(undefined)
+    ;(User.findOne as jest.Mock).mockResolvedValue(undefined)
     const res = createResponse()
 
     await AuthController.login(req, res)
@@ -146,12 +146,12 @@ describe('AuthController.login', () => {
       },
     })
 
-      ; (User.findOne as jest.Mock).mockResolvedValue({
-        id: 1,
-        email: 'test@example.com',
-        password: 'password',
-        confirmed: false,
-      })
+    ;(User.findOne as jest.Mock).mockResolvedValue({
+      id: 1,
+      email: 'test@example.com',
+      password: 'password',
+      confirmed: false,
+    })
 
     const res = createResponse()
 
@@ -183,13 +183,13 @@ describe('AuthController.login', () => {
       },
     })
 
-      ; (User.findOne as jest.Mock).mockResolvedValue({
-        id: 1,
-        email: 'test@example.com',
-        password: 'wrongpassword',
-        confirmed: true,
-      })
-      ; (checkPassword as jest.Mock).mockResolvedValue(false)
+    ;(User.findOne as jest.Mock).mockResolvedValue({
+      id: 1,
+      email: 'test@example.com',
+      password: 'wrongpassword',
+      confirmed: true,
+    })
+    ;(checkPassword as jest.Mock).mockResolvedValue(false)
     const res = createResponse()
 
     await AuthController.login(req, res)
@@ -227,9 +227,9 @@ describe('AuthController.login', () => {
 
     const temporaryJWT = 'temporary_jwt'
 
-      ; (User.findOne as jest.Mock).mockResolvedValue(userMock)
-      ; (checkPassword as jest.Mock).mockResolvedValue(true)
-      ; (generateJWT as jest.Mock).mockReturnValue(temporaryJWT)
+    ;(User.findOne as jest.Mock).mockResolvedValue(userMock)
+    ;(checkPassword as jest.Mock).mockResolvedValue(true)
+    ;(generateJWT as jest.Mock).mockReturnValue(temporaryJWT)
 
     await AuthController.login(req, res)
 
@@ -265,10 +265,10 @@ describe('AuthController.login', () => {
 
     const temporaryJWT = 'temporary_jwt'
 
-      ; (User.findOne as jest.Mock).mockRejectedValue(new Error())
-      // (checkPassword as jest.Mock).mockRejectedValue(new Error());
-      ; (checkPassword as jest.Mock).mockResolvedValue(true)
-      ; (generateJWT as jest.Mock).mockReturnValue(temporaryJWT)
+    ;(User.findOne as jest.Mock).mockRejectedValue(new Error())
+    // (checkPassword as jest.Mock).mockRejectedValue(new Error());
+    ;(checkPassword as jest.Mock).mockResolvedValue(true)
+    ;(generateJWT as jest.Mock).mockReturnValue(temporaryJWT)
 
     await AuthController.login(req, res)
 

--- a/frontend/libs/schemas/auth.ts
+++ b/frontend/libs/schemas/auth.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const registerSchema = z
+export const RegisterSchema = z
   .object({
     email: z
       .string()
@@ -24,7 +24,7 @@ export const registerSchema = z
     path: ["password_confirmation"],
   });
 
-export const loginSchema = z.object({
+export const LoginSchema = z.object({
   email: z
     .string()
     .min(1, "メールアドレスは必須です")
@@ -32,7 +32,7 @@ export const loginSchema = z.object({
   password: z.string().min(1, "パスワードは必須です"),
 });
 
-export const confirmAccountSchema = z.object({
+export const ConfirmAccountSchema = z.object({
   token: z
     .string()
     .min(1, "認証コードは必須です")
@@ -40,13 +40,22 @@ export const confirmAccountSchema = z.object({
     .regex(/^\d+$/, "認証コードは数字のみで入力してください"),
 });
 
-export const forgotPasswordSchema = z.object({
+export const ForgotPasswordSchema = z.object({
   email: z
     .string()
     .min(1, "メールアドレスは必須です")
     .email("有効なメールアドレスを入力してください"),
 });
 
-export type RegisterFormValues = z.infer<typeof registerSchema>;
-export type LoginFormValues = z.infer<typeof loginSchema>;
-export type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>;
+export const SuccessSchema = z.string()
+export const ErrorResponseSchema = z.object({
+        error: z.string()
+})
+
+
+export type RegisterFormValues = z.infer<typeof RegisterSchema>;
+export type LoginFormValues = z.infer<typeof LoginSchema>;
+export type ForgotPasswordFormValues = z.infer<typeof ForgotPasswordSchema>;
+// export type SuccessSchemaValues = z.infer<typeof SuccessSchema>
+// export type ErrorResponseEchemaValues = z.infer<typeof ErrorResponseSchema>
+

--- a/frontend/src/components/auth/ForgotPasswordForm.tsx
+++ b/frontend/src/components/auth/ForgotPasswordForm.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import { useRef, useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
-import { RegisterFormValues, registerSchema } from "../../../libs/schemas/auth";
+import { RegisterFormValues, RegisterSchema } from "../../../libs/schemas/auth";
 import Button from "../../components/ui/Button/Button";
 
 export default function ForgotPassword() {
@@ -35,7 +35,7 @@ export default function ForgotPassword() {
     formState: { errors, isSubmitting },
     reset,
   } = useForm<RegisterFormValues>({
-    resolver: zodResolver(registerSchema),
+    resolver: zodResolver(RegisterSchema),
     defaultValues: {
       email: "",
       name: "",


### PR DESCRIPTION
# ユーザー登録機能の実装 (Issue #52 )

## 概要
Next.jsフロントエンドからユーザー登録を行う機能を実装しました。サーバーアクションを使用してフォームデータを検証し、バックエンドAPIへ送信する処理を追加しています。

## 変更内容
- サーバーアクションを作成し、フォームデータ送信機能を実装
- zodを使用した入力データのバリデーション機構の実装
- useActionState と useFormStateを使ったサーバーアクション通信の実装
- 検証エラーメッセージの表示機能追加
- バックエンドAPIとの連携処理の実装
- 登録成功/エラー時のフィードバック表示（Alertコンポーネント使用）
- 登録成功時のフォームクリア処理
- ユーザーアカウント確認用メール送信設定

## テスト内容
- 各入力フィールドのバリデーションテスト
  - 必須項目の未入力時エラー表示
  - パスワード強度チェック
  - メールアドレス形式チェック
- サーバーアクションの動作確認
- バックエンドAPIとの連携テスト
- 成功/エラー表示の動作確認
- レスポンシブデザインの確認
- ユーザ登録関連の統合テスト

## 影響範囲
- ユーザー登録ページ (`/auth/register`)
- 認証関連のサーバーアクション
- 環境変数（バックエンドAPI接続用）

## 動作環境
- Node.js: v18.x
- Next.js: v14.x

## スクリーンショット
<!-- ここに必要なスクリーンショットを追加 -->

## 関連Issues
Closes #52