### PR TITLE
feat: アカウント有効化

### DIFF
--- a/frontend/actions/confirm-account-action.test.ts
+++ b/frontend/actions/confirm-account-action.test.ts
@@ -1,5 +1,5 @@
-import { register } from '../actions/create-account-action';
-import { ErrorResponseSchema, RegisterSchema } from "../libs/schemas/auth";
+import { ConfirmAccountSchema, ErrorResponseSchema } from '../libs/schemas/auth';
+import { confirm_account } from './confirm-account-action';
 
 // サーバーアクション用にfetchをモック化
 global.fetch = jest.fn();
@@ -27,7 +27,7 @@ class MockFormData {
 // モック用のzodモジュール
 jest.mock("../libs/schemas/auth", () => {
   return {
-    RegisterSchema: {
+    ConfirmAccountSchema: {
       safeParse: jest.fn(),
     },
     ErrorResponseSchema: {
@@ -36,49 +36,43 @@ jest.mock("../libs/schemas/auth", () => {
   };
 });
 
-describe('register サーバーアクション', () => {
+describe('confirm_account サーバーアクション', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('バリデーションに失敗した場合、エラーメッセージを返すこと', async () => {
     // バリデーション失敗のモック
-    (RegisterSchema.safeParse as jest.Mock).mockReturnValue({
+    (ConfirmAccountSchema.safeParse as jest.Mock).mockReturnValue({
       success: false,
       error: {
         errors: [
-          { message: 'メールアドレスは必須です' },
-          { message: 'パスワードは8文字以上で入力してください' },
+          { message: '認証コードは6桁でなければなりません' },
+          { message: '認証コードは数字のみで入力してください' }
         ]
       }
     });
 
     // FormDataの作成
     const formData = new MockFormData({
-      email: '',
-      name: 'テストユーザー',
-      password: '123',
-      password_confirmation: '123'
+      token: 'abc' // 無効なトークン
     }) as unknown as FormData;
 
     // 初期状態
     const prevState = { errors: [], success: '' };
 
     // アクションの実行
-    const result = await register(prevState, formData);
+    const result = await confirm_account(prevState, formData);
 
     // 期待する結果を検証
     expect(result).toEqual({
-      errors: ['メールアドレスは必須です', 'パスワードは8文字以上で入力してください'],
+      errors: ['認証コードは6桁でなければなりません', '認証コードは数字のみで入力してください'],
       success: ''
     });
 
-    // RegisterSchema.safeParseが正しい引数で呼び出されたことを確認
-    expect(RegisterSchema.safeParse).toHaveBeenCalledWith({
-      email: '',
-      name: 'テストユーザー',
-      password: '123',
-      password_confirmation: '123'
+    // ConfirmAccountSchema.safeParseが正しい引数で呼び出されたことを確認
+    expect(ConfirmAccountSchema.safeParse).toHaveBeenCalledWith({
+      token: 'abc'
     });
 
     // fetchが呼び出されていないことを確認
@@ -87,58 +81,51 @@ describe('register サーバーアクション', () => {
 
   it('APIがエラーステータス409を返した場合、エラーメッセージを返すこと', async () => {
     // バリデーション成功のモック
-    (RegisterSchema.safeParse as jest.Mock).mockReturnValue({
+    (ConfirmAccountSchema.safeParse as jest.Mock).mockReturnValue({
       success: true,
       data: {
-        email: 'test@example.com',
-        name: 'テストユーザー',
-        password: 'password123',
+        token: '123456'
       }
     });
 
     // ErrorResponseSchemaのモック
     (ErrorResponseSchema.parse as jest.Mock).mockReturnValue({
-      error: 'そのメールアドレスは既に登録されています。'
+      error: '無効な認証コードです'
     });
 
     // fetch APIの応答をモック
     (global.fetch as jest.Mock).mockResolvedValue({
       status: 409,
-      json: async () => ({ error: 'そのメールアドレスは既に登録されています。' })
+      json: async () => ({ error: '無効な認証コードです' })
     });
 
     // FormDataの作成
     const formData = new MockFormData({
-      email: 'test@example.com',
-      name: 'テストユーザー',
-      password: 'password123',
-      password_confirmation: 'password123'
+      token: '123456'
     }) as unknown as FormData;
 
     // 初期状態
     const prevState = { errors: [], success: '' };
 
     // アクションの実行
-    const result = await register(prevState, formData);
+    const result = await confirm_account(prevState, formData);
 
     // 期待する結果を検証
     expect(result).toEqual({
-      errors: ['そのメールアドレスは既に登録されています。'],
+      errors: ['無効な認証コードです'],
       success: ''
     });
 
     // fetchが正しく呼び出されたことを確認
     expect(fetch).toHaveBeenCalledWith(
-      `${process.env.API_URL}/auth/create-account`,
+      `${process.env.API_URL}/auth/confirm-account`,
       expect.objectContaining({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          name: 'テストユーザー',
-          password: 'password123',
-          email: 'test@example.com'
+          token: '123456'
         })
       })
     );
@@ -146,126 +133,109 @@ describe('register サーバーアクション', () => {
 
   it('APIが文字列として成功メッセージを返した場合、成功メッセージを返すこと', async () => {
     // バリデーション成功のモック
-    (RegisterSchema.safeParse as jest.Mock).mockReturnValue({
+    (ConfirmAccountSchema.safeParse as jest.Mock).mockReturnValue({
       success: true,
       data: {
-        email: 'test@example.com',
-        name: 'テストユーザー',
-        password: 'password123',
+        token: '123456'
       }
     });
 
     // fetch APIの応答をモック
     (global.fetch as jest.Mock).mockResolvedValue({
       status: 200,
-      json: async () => "アカウントが正常に作成されました"
+      json: async () => "アカウントが確認されました"
     });
 
     // FormDataの作成
     const formData = new MockFormData({
-      email: 'test@example.com',
-      name: 'テストユーザー',
-      password: 'password123',
-      password_confirmation: 'password123'
+      token: '123456'
     }) as unknown as FormData;
 
     // 初期状態
     const prevState = { errors: [], success: '' };
 
     // アクションの実行
-    const result = await register(prevState, formData);
+    const result = await confirm_account(prevState, formData);
 
     // 期待する結果を検証
     expect(result).toEqual({
       errors: [],
-      success: "アカウントが正常に作成されました"
+      success: "アカウントが確認されました"
     });
   });
 
   it('APIが成功オブジェクトを返した場合、成功メッセージを返すこと', async () => {
     // バリデーション成功のモック
-    (RegisterSchema.safeParse as jest.Mock).mockReturnValue({
+    (ConfirmAccountSchema.safeParse as jest.Mock).mockReturnValue({
       success: true,
       data: {
-        email: 'test@example.com',
-        name: 'テストユーザー',
-        password: 'password123',
+        token: '123456'
       }
     });
 
     // fetch APIの応答をモック
     (global.fetch as jest.Mock).mockResolvedValue({
       status: 200,
-      json: async () => ({ success: "アカウントが正常に作成されました" })
+      json: async () => ({ success: "アカウントが確認されました" })
     });
 
     // FormDataの作成
     const formData = new MockFormData({
-      email: 'test@example.com',
-      name: 'テストユーザー',
-      password: 'password123',
-      password_confirmation: 'password123'
+      token: '123456'
     }) as unknown as FormData;
 
     // 初期状態
     const prevState = { errors: [], success: '' };
 
     // アクションの実行
-    const result = await register(prevState, formData);
+    const result = await confirm_account(prevState, formData);
 
     // 期待する結果を検証
     expect(result).toEqual({
       errors: [],
-      success: "アカウントが正常に作成されました"
+      success: "アカウントが確認されました"
     });
   });
 
   it('APIがmessageオブジェクトを返した場合、成功メッセージを返すこと', async () => {
     // バリデーション成功のモック
-    (RegisterSchema.safeParse as jest.Mock).mockReturnValue({
+    (ConfirmAccountSchema.safeParse as jest.Mock).mockReturnValue({
       success: true,
       data: {
-        email: 'test@example.com',
-        name: 'テストユーザー',
-        password: 'password123',
+        token: '123456'
       }
     });
 
     // fetch APIの応答をモック
     (global.fetch as jest.Mock).mockResolvedValue({
       status: 200,
-      json: async () => ({ message: "アカウントが正常に作成されました" })
+      json: async () => ({ message: "アカウントが確認されました" })
     });
 
     // FormDataの作成
     const formData = new MockFormData({
-      email: 'test@example.com',
-      name: 'テストユーザー',
-      password: 'password123',
-      password_confirmation: 'password123'
+      token: '123456'
     }) as unknown as FormData;
 
     // 初期状態
     const prevState = { errors: [], success: '' };
 
     // アクションの実行
-    const result = await register(prevState, formData);
+    const result = await confirm_account(prevState, formData);
 
     // 期待する結果を検証
     expect(result).toEqual({
       errors: [],
-      success: "アカウントが正常に作成されました"
+      success: "アカウントが確認されました"
     });
   });
 
   it('APIが予期しない応答形式を返した場合、エラーメッセージを返すこと', async () => {
     // バリデーション成功のモック
-    (RegisterSchema.safeParse as jest.Mock).mockReturnValue({
+    (ConfirmAccountSchema.safeParse as jest.Mock).mockReturnValue({
       success: true,
       data: {
-        email: 'test@example.com',
-        name: 'テストユーザー',
-        password: 'password123',
+        token: '123456'
       }
     });
 
@@ -277,17 +247,14 @@ describe('register サーバーアクション', () => {
 
     // FormDataの作成
     const formData = new MockFormData({
-      email: 'test@example.com',
-      name: 'テストユーザー',
-      password: 'password123',
-      password_confirmation: 'password123'
+      token: '123456'
     }) as unknown as FormData;
 
     // 初期状態
     const prevState = { errors: [], success: '' };
 
     // アクションの実行
-    const result = await register(prevState, formData);
+    const result = await confirm_account(prevState, formData);
 
     // 期待する結果を検証
     expect(result).toEqual({

--- a/frontend/actions/confirm-account-action.ts
+++ b/frontend/actions/confirm-account-action.ts
@@ -1,0 +1,76 @@
+"use server"
+import { ConfirmAccountSchema, ErrorResponseSchema } from '../libs/schemas/auth';
+
+type ActionStateType = {
+  errors: string[];
+  success: string;
+}
+
+export async function confirm_account(prevState: ActionStateType, formData: FormData) {
+  //todo: formDataがどこからとっているか確認して学ぶ
+  const confirmAccountData = {
+    token: formData.get("token")
+  }
+
+  const confirm_account = ConfirmAccountSchema.safeParse(confirmAccountData)
+  if(!confirm_account.success) {
+    const errors = confirm_account.error.errors.map((error) => error.message)
+    return {
+      errors,
+      success: prevState.success
+    }
+  }
+
+  const url = `${process.env.API_URL}/auth/confirm-account`;
+  const req = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      token: confirm_account.data.token,
+    })
+  })
+
+  const json = await req.json();
+
+  console.log("API Response:", json);
+
+  if (req.status === 409) {
+    const { error } = ErrorResponseSchema.parse(json)
+    return {
+      errors: [error],
+      success: ""
+    }
+  }
+
+  if (typeof json === "string") {
+    // レスポンスが文字列の場合
+    return {
+      errors: [],
+      success: json,
+    };
+  } else if (json && typeof json === "object") {
+    // レスポンスがオブジェクトの場合
+    if ("success" in json && typeof json.success === "string") {
+      // success プロパティが存在し、文字列の場合
+      return {
+        errors: [],
+        success: json.success,
+      };
+    } else if ("message" in json && typeof json.message === "string") {
+      // message プロパティが存在し、文字列の場合
+      return {
+        errors: [],
+        success: json.message,
+      };
+    }
+  }
+
+  return {
+    errors: [
+      "レスポンス形式が予期しないものでした。管理者にお問い合わせください。",
+    ],
+    success: ""
+  }
+}

--- a/frontend/libs/schemas/auth.ts
+++ b/frontend/libs/schemas/auth.ts
@@ -53,6 +53,7 @@ export const ErrorResponseSchema = z.object({
 });
 
 export type RegisterFormValues = z.infer<typeof RegisterSchema>;
+export type ConfirmAccountFormValues = z.infer<typeof ConfirmAccountSchema>
 export type LoginFormValues = z.infer<typeof LoginSchema>;
 export type ForgotPasswordFormValues = z.infer<typeof ForgotPasswordSchema>;
 // export type SuccessSchemaValues = z.infer<typeof SuccessSchema>

--- a/frontend/src/components/auth/ConfirmAccount.test.tsx
+++ b/frontend/src/components/auth/ConfirmAccount.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useFormState } from "react-dom";
+import ConfirmAccountForm from "./ConfirmAccount";
+
+// モック関数のセットアップ
+jest.mock("@hookform/resolvers/zod", () => ({
+  zodResolver: jest.fn(() => ({}))
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn()
+  })
+}));
+
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  useFormState: jest.fn()
+}));
+
+jest.mock("../../../actions/confirm-account-action", () => ({
+  confirm_account: jest.fn()
+}));
+
+describe("ConfirmAccountFormコンポーネントのテスト", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("ユーザ有効化用のフォームが正しくレンダリングされるかのテストケース", () => {
+    // useFormStateモックを設定
+    (useFormState as jest.Mock).mockReturnValue([
+      { errors: [], success: "" }, 
+      jest.fn()
+    ]);
+
+    render(<ConfirmAccountForm />);
+
+    // タイトルが表示されているか確認
+    expect(screen.getByText("認証コードを入力してください")).toBeInTheDocument();
+    
+    // 6つの入力フィールドが表示されているか確認
+    const inputFields = screen.getAllByRole("textbox");
+    expect(inputFields).toHaveLength(6);
+
+    // 説明テキストが表示されているか確認
+    expect(screen.getByText("メールに送信された6桁の認証コードを入力してください")).toBeInTheDocument();
+  });
+
+  it("フォーム送信に成功したとき、成功のAlertコンポーネントとメッセージを表示する", async () => {
+    const successMessage = "アカウントが正常に確認されました";
+    
+    // useFormStateモックを設定 - 成功ケース
+    (useFormState as jest.Mock).mockReturnValue([
+      { errors: [], success: successMessage }, 
+      jest.fn()
+    ]);
+
+    render(<ConfirmAccountForm />);
+
+    // 成功メッセージが表示されているか確認
+    const successAlert = screen.getByText(successMessage);
+    expect(successAlert).toBeInTheDocument();
+    
+    // Alert要素が存在するかどうかだけを確認
+    // MUIコンポーネントはseverityを直接DOM属性として公開していない可能性がある
+    expect(successAlert).toBeInTheDocument();
+  });
+
+  it("フォーム送信に失敗したとき、エラーのAlertコンポーネントとメッセージを表示する", () => {
+    const errorMessage = "認証コードが無効です";
+    
+    // useFormStateモックを設定 - エラーケース
+    (useFormState as jest.Mock).mockReturnValue([
+      { errors: [errorMessage], success: "" }, 
+      jest.fn()
+    ]);
+
+    render(<ConfirmAccountForm />);
+
+    // エラーメッセージが表示されているか確認
+    const errorAlert = screen.getByText(errorMessage);
+    expect(errorAlert).toBeInTheDocument();
+  });
+
+  it("6桁のコードを入力したとき、フォームが自動的に送信される", async () => {
+    // フォーム送信のモック
+    const mockFormAction = jest.fn();
+    (useFormState as jest.Mock).mockReturnValue([
+      { errors: [], success: "" }, 
+      mockFormAction
+    ]);
+
+    // requestSubmitメソッドのモック
+    const mockRequestSubmit = jest.fn();
+    HTMLFormElement.prototype.requestSubmit = mockRequestSubmit;
+
+    render(<ConfirmAccountForm />);
+
+    // 入力フィールドを取得
+    const inputFields = screen.getAllByRole("textbox");
+    
+    // 各フィールドに値を入力
+    for (let i = 0; i < 6; i++) {
+      fireEvent.change(inputFields[i], { target: { value: String(i) } });
+    }
+
+    // フォームが自動送信されることを確認
+    await waitFor(() => {
+      expect(mockRequestSubmit).toHaveBeenCalled();
+    });
+  });
+
+  it("コピーペーストした値が適切に処理される", async () => {
+    // フォーム送信のモック
+    const mockFormAction = jest.fn();
+    (useFormState as jest.Mock).mockReturnValue([
+      { errors: [], success: "" }, 
+      mockFormAction
+    ]);
+
+    render(<ConfirmAccountForm />);
+
+    // 入力フィールドを取得
+    const inputFields = screen.getAllByRole("textbox");
+    
+    // 最初のフィールドに複数の数字を一度に入力（コピーペーストをシミュレート）
+    fireEvent.change(inputFields[0], { target: { value: "123456" } });
+
+    // 全てのフィールドに値が入力されているか確認
+    await waitFor(() => {
+      for (let i = 0; i < 6; i++) {
+        expect(inputFields[i]).toHaveValue(String(i + 1));
+      }
+    });
+  });
+});


### PR DESCRIPTION
## 概要
#59 

## 変更内容
- アカウント有効化の画面を作成
- 6桁のトークンが入力された後、正しい場合と間違っている場合でフラッシュメッセージを表示
- 成功時、ログイン画面にリダイレクトするように実装
- 上記のテストコードを実装