### PR TITLE
feat 32 パスワードを忘れた場合の再設定用メアド送信機能

### DIFF
--- a/frontend/actions/forget-password-action.test.ts
+++ b/frontend/actions/forget-password-action.test.ts
@@ -1,0 +1,174 @@
+import {
+  ErrorResponseSchema,
+  ForgotPasswordSchema,
+} from "../libs/schemas/auth";
+import { forget_password } from "./forget-password-action";
+
+global.fetch = jest.fn();
+
+class MockFormData {
+  private data = new Map();
+
+  constructor(initialData = {}) {
+    Object.entries(initialData).forEach(([key, value]) => {
+      this.data.set(key, value);
+    });
+  }
+
+  get(key) {
+    return this.data.get(key);
+  }
+
+  set(key, value) {
+    this.data.set(key, value);
+    return this;
+  }
+}
+
+jest.mock("../libs/schemas/auth", () => {
+  return {
+    ForgotPasswordSchema: {
+      safeParse: jest.fn(),
+    },
+    ErrorResponseSchema: {
+      parse: jest.fn(),
+    },
+  };
+});
+
+describe("forgot-password サーバアクション", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("バリデーションに失敗した場合、エラーメッセージを返すこと", async () => {
+    ForgotPasswordSchema.safeParse.mockReturnValue({
+      success: false,
+      error: {
+        errors: [{ message: "メールアドレスは必須です" }],
+      },
+    });
+
+    const formData = new MockFormData({
+      email: "",
+    }) as unknown as FormData;
+
+    const prevState = { errors: [], success: "" };
+
+    const result = await forget_password(prevState, formData);
+
+    expect(result).toEqual({
+      errors: ["メールアドレスは必須です"],
+      success: "",
+    });
+
+    expect(ForgotPasswordSchema.safeParse).toHaveBeenCalledWith({
+      email: "",
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("APIがエラーステータス409を返した場合、エラーメッセージを返すこと", async () => {
+    ForgotPasswordSchema.safeParse.mockReturnValue({
+      success: true,
+      data: {
+        email: "not-found-user@example.com", // ここを変更！
+      },
+    });
+
+    ErrorResponseSchema.parse.mockReturnValue({
+      error: "ユーザが見つかりません",
+    });
+
+    global.fetch.mockResolvedValue({
+      status: 409,
+      json: async () => ({
+        error: "ユーザが見つかりません",
+      }),
+    });
+
+    const formData = new MockFormData({
+      email: "not-found-user@example.com",
+    }) as unknown as FormData;
+
+    const prevState = { errors: [], success: "" };
+
+    const result = await forget_password(prevState, formData);
+
+    expect(result).toEqual({
+      errors: ["ユーザが見つかりません"],
+      success: "",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${process.env.API_URL}/auth/forgot-password`,
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "not-found-user@example.com",
+        }),
+      }),
+    );
+  });
+
+  it("APIが文字列として成功メッセージを返した場合、成功メッセージを返すこと", async () => {
+    ForgotPasswordSchema.safeParse.mockReturnValue({
+      success: true,
+      data: {
+        email: "test@example.com",
+      },
+    });
+
+    global.fetch.mockResolvedValue({
+      status: 201,
+      json: async () =>
+        "パスワードをリセットしました。メールを確認してください",
+    });
+
+    const formData = new MockFormData({
+      email: "test@example.com",
+    }) as unknown as FormData;
+
+    const prevState = { errors: [], success: "" };
+
+    const result = await forget_password(prevState, formData);
+
+    expect(result).toEqual({
+      errors: [],
+      success: "パスワードをリセットしました。メールを確認してください",
+    });
+  });
+
+  it("APIが予期しない応答形式をした場合、エラーメッセージを返すこと", async () => {
+    ForgotPasswordSchema.safeParse.mockReturnValue({
+      success: true,
+      data: {
+        email: "test@example.com",
+      },
+    });
+
+    global.fetch.mockResolvedValue({
+      status: 200,
+      json: async () => ({ unexpected_field: "予期しないレスポンス" }),
+    });
+
+    const formData = new MockFormData({
+      email: "test@example.com",
+    }) as unknown as FormData;
+
+    const prevState = { errors: [], success: "" };
+
+    const result = await forget_password(prevState, formData);
+
+    expect(result).toEqual({
+      errors: [
+        "レスポンス形式が予期しないものでした。管理者にお問い合わせください。",
+      ],
+      success: "",
+    });
+  });
+});

--- a/frontend/src/components/auth/ForgetPasswordForm.test.tsx
+++ b/frontend/src/components/auth/ForgetPasswordForm.test.tsx
@@ -1,33 +1,86 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import ForgotPassword from "./ForgotPasswordForm";
 
 jest.mock("@hookform/resolvers/zod", () => ({
-  zodResolver: jest.fn(() => ({}))
-}))
+  zodResolver: jest.fn(() => ({})),
+}));
 
 jest.mock("react-hook-form", () => ({
   useForm: () => ({
     register: jest.fn(),
     handleSubmit: jest.fn((fn) => (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      return fn({ email: "test@example.com" })
+      return fn({ email: "test@example.com" });
     }),
     formState: {
       errors: {},
-      isSubmitting: false
+      isSubmitting: false,
     },
-    reset: jest.fn()
-  })
-}))
+    reset: jest.fn(),
+  }),
+}));
 
 describe("ForgetPasswordFormコンポーネントのテスト", () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-  })
+    jest.clearAllMocks();
+  });
 
   it("パスワード再設定用のメアド送信フォームが正しくレンダリングされるかのテストケース", () => {
-    render(<ForgotPassword />)
+    render(<ForgotPassword />);
 
-    expect(screen.getByLabelText())
-  })
-})
+    expect(screen.getByLabelText(/メールアドレス/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /パスワードのリセット/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("フォーム送信に成功したとき、成功のAlertコンポーネントを表示する", () => {
+    const { rerender } = render(<ForgotPassword />);
+
+    expect(screen.queryByText(/success/i)).not.toBeInTheDocument();
+
+    rerender(<ForgotPassword />);
+
+    const submitButton = screen.getByRole("button", {
+      name: /パスワードのリセット/i,
+    });
+    fireEvent.click(submitButton);
+
+    //memo: 統合テストが必要
+  });
+
+  it("バリデーションエラーが出るとき、正しいエラーメッセージを表示できるかのテスト", () => {
+    const mockUseForm = {
+      register: jest.fn(),
+      handleSubmit: jest.fn(),
+      formState: {
+        errors: {
+          email: { message: "メールアドレスは必須です" },
+        },
+        isSubmitting: false,
+      },
+      reset: jest.fn(),
+    };
+    jest.mock("react-hook-form", () => ({
+      useForm: () => mockUseForm,
+    }));
+
+    //memo: jestのモックの制限によりmockUseFormを使ったrenderが難しいため、
+    //memo: 実際のテストでは別のアプローチが必要
+  });
+
+  it("送信中の場合、データが送信できないことを確認するテスト", () => {
+    const mockUseForm = {
+      register: jest.fn(),
+      handleSubmit: jest.fn(),
+      formState: {
+        errors: {},
+        isSubmitting: true,
+      },
+      reset: jest.fn(),
+    };
+    jest.mock("react-hook-form", () => ({
+      useForm: () => mockUseForm,
+    }));
+  });
+});


### PR DESCRIPTION
## 概要
#62 
## 変更内容
- メールアドレスを送信することで、再設定に必要なtokenを発行
- 関連テストコードを追加
- 