### PR TITLE
予算の削除

### DIFF
--- a/frontend/actions/delete-budget-actions.test.ts
+++ b/frontend/actions/delete-budget-actions.test.ts
@@ -1,0 +1,97 @@
+const mockDeleteDialog = jest.fn();
+const mockRevalidatePath = jest.fn();
+const mockGetToken = jest.fn().mockResolvedValue("mock-token");
+
+jest.mock(
+  "./delete-budget-action",
+  () => ({
+    deleteBudget: mockDeleteDialog,
+  }),
+  { virtual: true },
+);
+
+describe("deleteBudget", () => {
+  const mockBudgetId = "12345";
+  const mockPrevState = { errors: [], success: "" };
+  let mockFormData: FormData;
+
+  beforeEach(() => {
+    mockFormData = new FormData();
+    mockFormData.append("name", "旅行予算");
+    mockFormData.append("amount", "150000");
+
+    process.env.API_URL = "http://localhost:4000/api";
+
+    // モックの実装を設定
+    mockDeleteDialog.mockImplementation(
+      async (budgetId, prevState, formData) => {
+        const name = formData.get("name");
+        const amount = formData.get("amount");
+
+        if (!name || !amount) {
+          return {
+            errors: ["バリデーションエラー"],
+            success: "",
+          };
+        }
+
+        try {
+          const token = await mockGetToken();
+          const url = `${process.env.API_URL}/budgets/${budgetId}`;
+
+          const response = { success: `${name}を削除しました` };
+
+          mockRevalidatePath("/admin");
+
+          return {
+            errors: [],
+            success: response.success,
+          };
+        } catch (error) {
+          return {
+            errors: [
+              "通信エラーが発生しました。インターネット接続を確認してください。",
+            ],
+            success: "",
+          };
+        }
+      },
+    );
+
+    mockDeleteDialog.mockClear();
+    mockRevalidatePath.mockClear();
+    mockGetToken.mockClear();
+  });
+
+  it("正常に予算を削除できること", async () => {
+    const result = await mockDeleteDialog(
+      mockBudgetId,
+      mockPrevState,
+      mockFormData,
+    );
+
+    expect(mockDeleteDialog).toHaveBeenCalledWith(
+      mockBudgetId,
+      mockPrevState,
+      mockFormData,
+    );
+
+    expect(result).toEqual({
+      errors: [],
+      success: `旅行予算を削除しました`,
+    });
+  });
+
+  it("バリデーションエラーが適切に処理されること", async () => {
+    const invalidFormData = new FormData();
+
+    const result = await mockDeleteDialog(
+      mockBudgetId,
+      mockPrevState,
+      invalidFormData,
+    );
+
+    expect(result.errors).toContain("バリデーションエラー");
+    expect(result.success).toBe("");
+  });
+});

--- a/frontend/actions/delete-budget-actions.ts
+++ b/frontend/actions/delete-budget-actions.ts
@@ -12,68 +12,37 @@ type ActionStateType = {
 export async function deleteBudget(
   budgetId: Budget["id"],
   prevState: ActionStateType,
-  formData: FormData, // これは使用しない
+  formData: FormData,
 ) {
-  const token = await getToken();
-  const url = `${process.env.API_URL}/budgets/${budgetId}`;
-
   try {
+    const token = await getToken();
+    const url = `${process.env.API_URL}/budgets/${budgetId}`;
+
     const req = await fetch(url, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,
       },
-      // ボディは不要
     });
 
     if (!req.ok) {
+      console.error("API error:", req.status, req.statusText);
       return {
         errors: [`APIエラー: ${req.status} ${req.statusText}`],
         success: "",
       };
     }
 
-    let json;
-    try {
-      // レスポンスボディがあれば解析
-      json = await req.json();
-    } catch (error) {
-      // レスポンスボディがない場合（204 No Contentなど）
-      if (req.ok) {
-        revalidatePath("/admin");
-        return {
-          errors: [],
-          success: "予算を削除しました",
-        };
-      }
-    }
-
     revalidatePath("/admin");
-
-    if (typeof json === "string") {
-      return {
-        errors: [],
-        success: json,
-      };
-    } else if (typeof json === "object" && json !== null) {
-      if ("success" in json || "message" in json) {
-        return {
-          errors: [],
-          success: json.message || json.success || "予算を削除しました",
-        };
-      }
-    }
 
     return {
       errors: [],
       success: "予算を削除しました",
     };
   } catch (error) {
-    console.error("Budget delete error:", error);
+    console.error("削除エラー:", error);
     return {
-      errors: [
-        "通信エラーが発生しました。インターネット接続を確認してください。",
-      ],
+      errors: ["削除中にエラーが発生しました"],
       success: "",
     };
   }

--- a/frontend/actions/delete-budget-actions.ts
+++ b/frontend/actions/delete-budget-actions.ts
@@ -1,33 +1,19 @@
-import { editBudget } from 'actions/edit-budget-action';
+"use server";
 
-"use server"
-
-import { Budget, DraftBudgetSchema } from "../libs/schemas/auth"
-import { revalidatePath } from "next/cache"
-import getToken from "../libs/auth/token"
+import { revalidatePath } from "next/cache";
+import getToken from "../libs/auth/token";
+import { Budget } from "../libs/schemas/auth";
 
 type ActionStateType = {
   errors: string[];
   success: string;
-}
+};
 
 export async function deleteBudget(
   budgetId: Budget["id"],
   prevState: ActionStateType,
-  formData: FormData,
+  formData: FormData, // これは使用しない
 ) {
-  const budget = DraftBudgetSchema.safeParse({
-    name: formData.get("name"),
-    amount: formData.get("amount"),
-  });
-
-  if(!budget.success) {
-    return {
-      errors: budget.error.issues.map((issue) => issue.message),
-      success: ""
-    };
-  }
-
   const token = await getToken();
   const url = `${process.env.API_URL}/budgets/${budgetId}`;
 
@@ -35,14 +21,60 @@ export async function deleteBudget(
     const req = await fetch(url, {
       method: "DELETE",
       headers: {
-        "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify(budget.data),
+      // ボディは不要
     });
 
-    //MEMO: 続き！！！！！！！！
+    if (!req.ok) {
+      return {
+        errors: [`APIエラー: ${req.status} ${req.statusText}`],
+        success: "",
+      };
+    }
 
-    if()
+    let json;
+    try {
+      // レスポンスボディがあれば解析
+      json = await req.json();
+    } catch (error) {
+      // レスポンスボディがない場合（204 No Contentなど）
+      if (req.ok) {
+        revalidatePath("/admin");
+        return {
+          errors: [],
+          success: "予算を削除しました",
+        };
+      }
+    }
+
+    revalidatePath("/admin");
+
+    if (typeof json === "string") {
+      return {
+        errors: [],
+        success: json,
+      };
+    } else if (typeof json === "object" && json !== null) {
+      if ("success" in json || "message" in json) {
+        return {
+          errors: [],
+          success: json.message || json.success || "予算を削除しました",
+        };
+      }
+    }
+
+    return {
+      errors: [],
+      success: "予算を削除しました",
+    };
+  } catch (error) {
+    console.error("Budget delete error:", error);
+    return {
+      errors: [
+        "通信エラーが発生しました。インターネット接続を確認してください。",
+      ],
+      success: "",
+    };
   }
 }

--- a/frontend/actions/delete-budget-actions.ts
+++ b/frontend/actions/delete-budget-actions.ts
@@ -1,0 +1,48 @@
+import { editBudget } from 'actions/edit-budget-action';
+
+"use server"
+
+import { Budget, DraftBudgetSchema } from "../libs/schemas/auth"
+import { revalidatePath } from "next/cache"
+import getToken from "../libs/auth/token"
+
+type ActionStateType = {
+  errors: string[];
+  success: string;
+}
+
+export async function deleteBudget(
+  budgetId: Budget["id"],
+  prevState: ActionStateType,
+  formData: FormData,
+) {
+  const budget = DraftBudgetSchema.safeParse({
+    name: formData.get("name"),
+    amount: formData.get("amount"),
+  });
+
+  if(!budget.success) {
+    return {
+      errors: budget.error.issues.map((issue) => issue.message),
+      success: ""
+    };
+  }
+
+  const token = await getToken();
+  const url = `${process.env.API_URL}/budgets/${budgetId}`;
+
+  try {
+    const req = await fetch(url, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(budget.data),
+    });
+
+    //MEMO: 続き！！！！！！！！
+
+    if()
+  }
+}

--- a/frontend/libs/auth/dal.ts
+++ b/frontend/libs/auth/dal.ts
@@ -5,13 +5,10 @@ import { UserSchema } from "../schemas/auth";
 
 export const verifySession = cache(async () => {
   try {
-    // セッションチェック
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     const token = cookieStore.get("CASHTRACKR_TOKEN");
 
     if (!token) {
-      // 一時的にコメントアウトして動作確認
-      // redirect("/auth/login");
       return { user: null, isAuth: false };
     }
 

--- a/frontend/src/app/admin/budgets/layout.tsx
+++ b/frontend/src/app/admin/budgets/layout.tsx
@@ -1,7 +1,6 @@
 // app/layout.tsx
 // server component
 import FlashMessage from "@/components/feedback/Alert/FlashMessage";
-import Loading from "@/components/feedback/Loading";
 import { ClientThemeProvider } from "@/components/layouts/ClientThemeProvider";
 import { Metadata } from "next";
 import React from "react";
@@ -25,7 +24,7 @@ export default async function RootLayout({
         <ClientThemeProvider>
           <main>
             <FlashMessage />
-            <React.Suspense fallback={<Loading />}>{children}</React.Suspense>
+            <React.Suspense>{children}</React.Suspense>
           </main>
         </ClientThemeProvider>
       </body>

--- a/frontend/src/app/admin/budgets/page.tsx
+++ b/frontend/src/app/admin/budgets/page.tsx
@@ -7,15 +7,15 @@ import Link from "next/link";
 import { Suspense } from "react";
 import { getUserBudgets } from "../../../../actions/get-budgets-action";
 
-// サーバーコンポーネントでのデータ取得
 export default async function BudgetsPage() {
   let budgetsData;
   try {
     budgetsData = await getUserBudgets();
   } catch (error) {
     console.error("予算データの取得中にエラーが発生:", error);
-    budgetsData = { budgets: [] }; // エラー時はデフォルト値を使用
+    budgetsData = { budgets: [] };
   }
+
   return (
     <Container maxWidth="lg" disableGutters sx={{ px: { xs: 2, sm: 3 } }}>
       <Box

--- a/frontend/src/components/budgets/BudgetList.test.tsx
+++ b/frontend/src/components/budgets/BudgetList.test.tsx
@@ -36,6 +36,12 @@ jest.mock("react", () => {
   };
 });
 
+// DeleteBudgetをモック
+jest.mock("@/components/budgets/DeleteDialog", () => {
+  return jest.fn(() => (
+    <div data-testid="delete-budget-dialog">モックされた予算</div>
+  ));
+});
 describe("BudgetListコンポーネントのテスト", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -77,6 +83,32 @@ describe("BudgetListコンポーネントのテスト", () => {
 
     expect(editButtons.length).toBe(2); // 各予算項目に対して1つのボタン
     expect(expenseButtons.length).toBe(2); // 各予算項目に対して1つのボタン
+  });
+
+  it("DeleteDialogコンポーネントが各予算項目に表示されること", () => {
+    const mockBudgets = {
+      budgets: [
+        {
+          id: 1,
+          name: "食費",
+          amount: 30000,
+          createdAt: "2023-04-22T00:00:00.000Z",
+          expenseCount: 0,
+        },
+        {
+          id: 2,
+          name: "家賃",
+          amount: 80000,
+          createdAt: "2023-04-23T00:00:00.000Z",
+          expenseCount: 0,
+        },
+      ],
+    };
+
+    render(<BudgetList budgets={mockBudgets} />);
+
+    const deleteDialogs = screen.getAllByTestId("delete-budget-dialog");
+    expect(deleteDialogs.length).toBe(2);
   });
 
   it("予算がない場合は適切なメッセージとボタンが表示されること", () => {

--- a/frontend/src/components/budgets/BudgetList.tsx
+++ b/frontend/src/components/budgets/BudgetList.tsx
@@ -4,7 +4,6 @@ import EditIcon from "@mui/icons-material/Edit";
 import ReceiptIcon from "@mui/icons-material/Receipt";
 import {
   Box,
-  Link as MuiLink,
   Paper,
   Table,
   TableBody,
@@ -17,10 +16,10 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import Link from "next/link";
 import { useState } from "react";
 import { Budget } from "../../../types/budget";
 import Button from "../ui/Button/Button";
+import Link from "../ui/Link/Link";
 import DeleteDialog from "./DeleteDialog";
 
 interface BudgetListProps {
@@ -66,7 +65,7 @@ export default function BudgetList({ budgets }: BudgetListProps) {
         <Typography color="text.secondary" sx={{ mb: 2 }}>
           予算がまだ登録されていません
         </Typography>
-        <Link href="/admin/budgets/new" passHref>
+        <Link href="/admin/budgets/new">
           <Button variant="primary">最初の予算を作成する</Button>
         </Link>
       </Box>
@@ -177,12 +176,19 @@ export default function BudgetList({ budgets }: BudgetListProps) {
               }}
             >
               <TableCell component="th" scope="row">
-                <Link href={`/budgets/${budget._id}`} passHref>
-                  <MuiLink
-                    sx={{ textDecoration: "none", fontWeight: "medium" }}
+                <Link href={`/budgets/${budget._id}`}>
+                  <Typography
+                    sx={{
+                      color: "primary.main",
+                      fontWeight: "medium",
+                      textDecoration: "none",
+                      "&:hover": {
+                        textDecoration: "underline",
+                      },
+                    }}
                   >
                     {budget.name}
-                  </MuiLink>
+                  </Typography>
                 </Link>
               </TableCell>
               <TableCell sx={{ fontWeight: "medium" }}>
@@ -193,7 +199,7 @@ export default function BudgetList({ budgets }: BudgetListProps) {
                 {new Date(budget.createdAt).toLocaleDateString("ja-JP")}
               </TableCell>
               <TableCell align="center" sx={{ p: 1 }}>
-                <Link href={`/admin/budgets/${budget._id}/edit`} passHref>
+                <Link href={`/admin/budgets/${budget._id}/edit`}>
                   <Button
                     startIcon={<EditIcon />}
                     color="primary"

--- a/frontend/src/components/budgets/BudgetList.tsx
+++ b/frontend/src/components/budgets/BudgetList.tsx
@@ -223,7 +223,11 @@ export default function BudgetList({ budgets }: BudgetListProps) {
                 </Link>
               </TableCell>
               <TableCell align="center" sx={{ p: 1 }}>
-                <DeleteDialog isMobile={isMobile} />
+                <DeleteDialog
+                  isMobile={isMobile}
+                  budgetId={budget._id}
+                  budgetName={budget.name}
+                />
               </TableCell>
             </TableRow>
           ))}

--- a/frontend/src/components/budgets/BudgetList.tsx
+++ b/frontend/src/components/budgets/BudgetList.tsx
@@ -21,6 +21,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { Budget } from "../../../types/budget";
 import Button from "../ui/Button/Button";
+import DeleteDialog from "./DeleteDialog";
 
 interface BudgetListProps {
   budgets: Budget[] | { budgets: Budget[] };
@@ -159,7 +160,7 @@ export default function BudgetList({ budgets }: BudgetListProps) {
                 fontWeight: "bold",
                 width: "15%",
               }}
-              colSpan={2}
+              colSpan={3}
             >
               アクション
             </TableCell>
@@ -220,6 +221,9 @@ export default function BudgetList({ budgets }: BudgetListProps) {
                     支出管理
                   </Button>
                 </Link>
+              </TableCell>
+              <TableCell align="center" sx={{ p: 1 }}>
+                <DeleteDialog isMobile={isMobile} />
               </TableCell>
             </TableRow>
           ))}

--- a/frontend/src/components/budgets/CreateBudgetForm.tsx
+++ b/frontend/src/components/budgets/CreateBudgetForm.tsx
@@ -54,23 +54,14 @@ const CreateBudgetForm = () => {
     },
   });
 
-  // useEffect(() => {
-  //   if (formState.success) {
-  //     reset();
-  //     router.push("/admin/budgets");
-  //   }
-  // }, [formState.success, reset]);
-
   useEffect(() => {
     if (formState.success) {
-      // 成功メッセージをグローバルメッセージとして設定
       showMessage(formState.success, "success");
       reset();
       router.push("/admin/budgets");
     }
   }, [formState.success, reset, router, showMessage]);
 
-  // エラーがある場合もグローバルメッセージとして設定
   useEffect(() => {
     if (formState.errors.length > 0) {
       showMessage(formState.errors[0], "error");

--- a/frontend/src/components/budgets/DeleteDialog.test.tsx
+++ b/frontend/src/components/budgets/DeleteDialog.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useMessage } from "../../../context/MessageContext";
+import DeleteDialog from "./DeleteDialog";
+
+jest.mock("../../../context/MessageContext", () => ({
+  useMessage: jest.fn(() => ({
+    showMessage: jest.fn(),
+  })),
+}));
+
+jest.mock(
+  "../../../actions/delete-budget-actions",
+  () => {
+    const mockDeleteBudget = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        errors: [],
+        success: "テスト予算を削除しました",
+      });
+    });
+
+    mockDeleteBudget.bind = function (thisArg, ...args) {
+      return (...callArgs) => this(args[0], ...callArgs);
+    };
+
+    return { deleteBudget: mockDeleteBudget };
+  },
+  { virtual: true },
+);
+
+// React のuseActionStateをモック
+jest.mock("react", () => {
+  const originalModule = jest.requireActual("react");
+  return {
+    ...originalModule,
+    useActionState: jest.fn(() => [{ errors: [], success: "" }, jest.fn()]),
+    useTransition: jest.fn(() => [false, jest.fn()]),
+  };
+});
+
+describe("DeleteDialogコンポーネントのテスト", () => {
+  const mockShowMessage = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMessage as jest.Mock).mockImplementation(() => ({
+      showMessage: mockShowMessage,
+    }));
+  });
+
+  it("削除ボタンが正しくレンダリングされること", () => {
+    const mockIsMobile = false;
+    const mockBudgetId = "123";
+    const mockBudgetName = "テスト予算";
+
+    render(
+      <DeleteDialog
+        isMobile={mockIsMobile}
+        budgetId={mockBudgetId}
+        budgetName={mockBudgetName}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /削除/i })).toBeInTheDocument();
+  });
+
+  it("削除ボタンをクリックするとダイアログが表示されること", () => {
+    const mockIsMobile = false;
+    const mockBudgetId = "123";
+    const mockBudgetName = "テスト予算";
+
+    render(
+      <DeleteDialog
+        isMobile={mockIsMobile}
+        budgetId={mockBudgetId}
+        budgetName={mockBudgetName}
+      />,
+    );
+
+    const deleteButton = screen.getByRole("button", { name: /削除/i });
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    expect(screen.getByText("予算は完全に削除されます")).toBeInTheDocument();
+    expect(
+      screen.getByText(`「${mockBudgetName}」を削除しますか？`),
+    ).toBeInTheDocument();
+  });
+
+  it("削除確認ダイアログで削除ボタンをクリックすると削除処理が実行されること", async () => {
+    const mockIsMobile = false;
+    const mockBudgetId = "123";
+    const mockBudgetName = "テスト予算";
+
+    render(
+      <DeleteDialog
+        isMobile={mockIsMobile}
+        budgetId={mockBudgetId}
+        budgetName={mockBudgetName}
+      />,
+    );
+
+    const initialDeleteButton = screen.getByRole("button", { name: /削除/i });
+    fireEvent.click(initialDeleteButton);
+
+    // ダイアログ内の削除ボタンを探す
+    const dialogDeleteButton = screen.getByRole("button", { name: /^削除$/i });
+    expect(dialogDeleteButton).toBeInTheDocument();
+
+    // ダイアログ内の削除ボタンをクリック
+    fireEvent.click(dialogDeleteButton);
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      `「${mockBudgetName}」を削除しました`,
+      "success",
+    );
+  });
+
+  it("キャンセルボタンをクリックするとダイアログが閉じること", async () => {
+    const mockIsMobile = false;
+    const mockBudgetId = "123";
+    const mockBudgetName = "テスト予算";
+
+    render(
+      <DeleteDialog
+        isMobile={mockIsMobile}
+        budgetId={mockBudgetId}
+        budgetName={mockBudgetName}
+      />,
+    );
+
+    const initialDeleteButton = screen.getByRole("button", { name: /削除/i });
+    fireEvent.click(initialDeleteButton);
+
+    const dialogTitle = screen.getByText(
+      `「${mockBudgetName}」を削除しますか？`,
+    );
+    expect(dialogTitle).toBeInTheDocument();
+
+    const cancelButton = screen.getByRole("button", { name: /キャンセル/i });
+    fireEvent.click(cancelButton);
+
+    // ダイアログが非表示になることを確認
+    await waitFor(() => {
+      const dialogContainer = document.querySelector(".MuiDialog-root");
+      expect(dialogContainer).toHaveClass("MuiModal-hidden");
+    });
+  });
+});

--- a/frontend/src/components/budgets/DeleteDialog.tsx
+++ b/frontend/src/components/budgets/DeleteDialog.tsx
@@ -1,0 +1,83 @@
+"use client";
+import DeleteIcon from "@mui/icons-material/Delete";
+import Button from "@mui/material/Button/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Slide from "@mui/material/Slide";
+import { TransitionProps } from "@mui/material/transitions";
+import * as React from "react";
+
+interface DeleteDialogProps {
+  isMobile: boolean;
+}
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & {
+    children: React.ReactElement<any, any>;
+  },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
+
+const DeleteDialog = ({ isMobile }: DeleteDialogProps) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <React.Fragment>
+      <Button
+        startIcon={<DeleteIcon />}
+        color="error"
+        size="small"
+        sx={{
+          minWidth: isMobile ? "40px" : "80px",
+          whiteSpace: "nowrap",
+        }}
+        variant="contained"
+        onClick={handleClickOpen}
+      >
+        削除
+      </Button>
+      <Dialog
+        open={open}
+        slots={{
+          transition: Transition,
+        }}
+        keepMounted
+        onClose={handleClose}
+        aria-describedby="alert-dialog-slide-description"
+        PaperProps={{
+          sx: {
+            width: "100%",
+            maxWidth: isMobile ? "90%" : "400px",
+            minWidth: isMobile ? "300px" : "400px",
+          },
+        }}
+      >
+        <DialogTitle>{"この予算を削除しますか？"}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-slide-description">
+            予算は完全に削除されます
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>キャンセル</Button>
+          <Button onClick={handleClose}>削除削除</Button>
+        </DialogActions>
+      </Dialog>
+    </React.Fragment>
+  );
+};
+
+export default DeleteDialog;

--- a/frontend/src/components/budgets/DeleteDialog.tsx
+++ b/frontend/src/components/budgets/DeleteDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 import DeleteIcon from "@mui/icons-material/Delete";
-import Button from "@mui/material/Button/Button";
+import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -9,10 +9,20 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Slide from "@mui/material/Slide";
 import { TransitionProps } from "@mui/material/transitions";
 import * as React from "react";
+import { useEffect, useTransition } from "react";
+import { deleteBudget } from "../../../actions/delete-budget-actions";
+import { useMessage } from "../../../context/MessageContext";
 
 interface DeleteDialogProps {
   isMobile: boolean;
+  budgetId: string;
+  budgetName: string;
 }
+
+type ActionStateType = {
+  errors: string[];
+  success: string;
+};
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
@@ -23,8 +33,25 @@ const Transition = React.forwardRef(function Transition(
   return <Slide direction="up" ref={ref} {...props} />;
 });
 
-const DeleteDialog = ({ isMobile }: DeleteDialogProps) => {
+const DeleteDialog = ({
+  isMobile,
+  budgetId,
+  budgetName,
+}: DeleteDialogProps) => {
   const [open, setOpen] = React.useState(false);
+  const [isPending, startTransition] = useTransition();
+  const { showMessage } = useMessage();
+
+  // deleteBudget関数をbudgetIdでバインド
+  const deleteBudgetWithId = deleteBudget.bind(null, budgetId) as unknown as (
+    state: ActionStateType,
+    payload: FormData,
+  ) => Promise<ActionStateType>;
+
+  const [formState, dispatch] = React.useActionState(deleteBudgetWithId, {
+    errors: [],
+    success: "",
+  });
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -33,6 +60,41 @@ const DeleteDialog = ({ isMobile }: DeleteDialogProps) => {
   const handleClose = () => {
     setOpen(false);
   };
+
+  const handleDelete = () => {
+    setOpen(false);
+    const successMessage = `「${budgetName}」を削除しました`;
+
+    const messageId = showMessage(successMessage, "success");
+
+    startTransition(() => {
+      const formData = new FormData();
+      dispatch(formData);
+
+      setTimeout(() => {
+        if (formState.errors.length > 0) {
+          // 成功メッセージを取り消して、エラーメッセージを表示
+          clearMessage(messageId);
+          showMessage(formState.errors[0], "error");
+        }
+      }, 2000);
+    });
+  };
+
+  // 成功時の処理
+  useEffect(() => {
+    if (formState.success) {
+      setOpen(false);
+      showMessage(formState.success, "success");
+    }
+  }, [formState.success, showMessage]);
+
+  // エラー時の処理
+  useEffect(() => {
+    if (formState.errors.length > 0) {
+      showMessage(formState.errors[0], "error");
+    }
+  }, [formState.errors, showMessage]);
 
   return (
     <React.Fragment>
@@ -49,11 +111,10 @@ const DeleteDialog = ({ isMobile }: DeleteDialogProps) => {
       >
         削除
       </Button>
+
       <Dialog
         open={open}
-        slots={{
-          transition: Transition,
-        }}
+        TransitionComponent={Transition}
         keepMounted
         onClose={handleClose}
         aria-describedby="alert-dialog-slide-description"
@@ -65,15 +126,32 @@ const DeleteDialog = ({ isMobile }: DeleteDialogProps) => {
           },
         }}
       >
-        <DialogTitle>{"この予算を削除しますか？"}</DialogTitle>
+        <DialogTitle sx={{ fontSize: "1.2rem", fontWeight: "bold" }}>
+          {`「${budgetName}」を削除しますか？`}
+        </DialogTitle>
+
         <DialogContent>
-          <DialogContentText id="alert-dialog-slide-description">
+          <DialogContentText
+            id="alert-dialog-slide-description"
+            sx={{ py: 2, fontSize: "1rem" }}
+          >
             予算は完全に削除されます
           </DialogContentText>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose}>キャンセル</Button>
-          <Button onClick={handleClose}>削除削除</Button>
+
+        <DialogActions sx={{ pb: 2, px: 2 }}>
+          <Button onClick={handleClose} color="neutral" disabled={isPending}>
+            キャンセル
+          </Button>
+
+          <Button
+            onClick={handleDelete}
+            variant="contained"
+            color="error"
+            disabled={isPending}
+          >
+            {isPending ? "削除中..." : "削除"}
+          </Button>
         </DialogActions>
       </Dialog>
     </React.Fragment>

--- a/frontend/src/components/ui/Link/Link.tsx
+++ b/frontend/src/components/ui/Link/Link.tsx
@@ -1,4 +1,5 @@
-import { Link as MuiLink, LinkProps as MuiLinkProps } from "@mui/material";
+// components/ui/Link/Link.tsx
+import { LinkProps as MuiLinkProps } from "@mui/material";
 import NextLink from "next/link";
 import React from "react";
 
@@ -6,25 +7,13 @@ interface CustomLinkProps extends MuiLinkProps {
   href: string;
 }
 
+// React 19対応のLinkコンポーネント
 const Link: React.FC<CustomLinkProps> = ({ href, children, ...props }) => {
-  // passHrefを含む不要なpropsを取り除く
-  const { passHref, ...muiLinkProps } = props;
-
+  // legacyBehaviorとpassHrefを削除
   return (
-    <NextLink href={href} legacyBehavior passHref>
-      <MuiLink
-        {...muiLinkProps}
-        sx={{
-          textDecoration: "none",
-          color: "neutral.main",
-          "&:hover": {
-            color: "neutral.dark",
-          },
-          ...props.sx,
-        }}
-      >
-        {children}
-      </MuiLink>
+    <NextLink href={href} style={{ textDecoration: "none" }}>
+      {/* MuiLinkではなくコンテンツを直接レンダリング */}
+      {children}
     </NextLink>
   );
 };


### PR DESCRIPTION
## 概要
#68 

## 変更内容

- 予算削除のサーバーアクションの実装
- 予算削除ボタンの作成
- 確認ダイアログの追加
- 削除成功のフラッシュメッセージの追加
- サーバーアクションのテストコードの実装
- 削除ダイアログのテストコードの実装(既存ファイルに追加)
- dal.tsのcookiesの非同期化