### PR TITLE
予算詳細と支出の作成のテストコードの実装

### DIFF
--- a/frontend/actions/create-expense-action.test.ts
+++ b/frontend/actions/create-expense-action.test.ts
@@ -1,0 +1,366 @@
+import { DraftExpenseSchema } from "../libs/schemas/auth";
+
+const mockCreateExpense = jest.fn();
+const mockRevalidatePath = jest.fn();
+const mockGetToken = jest.fn().mockResolvedValue("mock-token");
+
+jest.mock(
+  "./create-expense-action",
+  () => ({
+    createExpense: mockCreateExpense,
+  }),
+  { virtual: true },
+);
+
+describe("DraftExpenseSchema", () => {
+  describe("正常なケース", () => {
+    it("有効なデータでバリデーションが成功すること", () => {
+      const validData = {
+        name: "支出テスト",
+        amount: 10000,
+      };
+
+      const result = DraftExpenseSchema.safeParse(validData);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validData);
+      }
+    });
+
+    it("数値文字列がnumberに変換されること", () => {
+      const dataWithStringAmount = {
+        name: "支出テスト",
+        amount: "5000",
+      };
+
+      const result = DraftExpenseSchema.safeParse(dataWithStringAmount);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.amount).toBe(5000);
+        expect(typeof result.data.amount).toBe("number");
+      }
+    });
+
+    it("小数点を含む金額が正しく処理されること", () => {
+      const dataWithDecimal = {
+        name: "支出テスト",
+        amount: "1500.5",
+      };
+
+      const result = DraftExpenseSchema.safeParse(dataWithDecimal);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.amount).toBe(1500.5);
+      }
+    });
+  });
+
+  describe("nameフィールドのバリデーション", () => {
+    it("nameが空文字の場合エラーになること", () => {
+      const invalidData = {
+        name: "",
+        amount: 1000,
+      };
+
+      const result = DraftExpenseSchema.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe("支出タイトルは必須です");
+        expect(result.error.issues[0].path).toEqual(["name"]);
+      }
+    });
+
+    it("nameがnullの場合エラーになること", () => {
+      const invalidData = {
+        name: null,
+        amount: 1000,
+      };
+
+      const result = DraftExpenseSchema.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("amountフィールドのバリデーション", () => {
+    it("amountが0の場合エラーになること", () => {
+      const invalidData = {
+        name: "支出テスト",
+        amount: 0,
+      };
+
+      const result = DraftExpenseSchema.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe("支出金額が0円未満です");
+        expect(result.error.issues[0].path).toEqual(["amount"]);
+      }
+    });
+
+    it("amountが負の値の場合エラーになること", () => {
+      const invalidData = {
+        name: "支出テスト",
+        amount: -1000,
+      };
+
+      const result = DraftExpenseSchema.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe("支出金額が0円未満です");
+      }
+    });
+
+    it("amountが数値に変換できない文字列の場合エラーになること", () => {
+      const invalidData = {
+        name: "支出テスト",
+        amount: "無効な文字列",
+      };
+
+      const result = DraftExpenseSchema.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe("支出金額の値が無効です");
+      }
+    });
+
+    it("amountがundefinedの場合エラーになること", () => {
+      const invalidData = {
+        name: "支出テスト",
+      };
+
+      const result = DraftExpenseSchema.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const amountError = result.error.issues.find(
+          (issue) => issue.path[0] === "amount",
+        );
+        expect(amountError?.message).toBe("支出金額の値が無効です");
+      }
+    });
+
+    it("amountがnullの場合エラーになること", () => {
+      const invalidData = {
+        name: "支出テスト",
+        amount: null,
+      };
+
+      const result = DraftExpenseSchema.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("複数フィールドエラーのケース", () => {
+    it("nameとamount両方が無効な場合、両方のエラーが返されること", () => {
+      const invalidData = {
+        name: "",
+        amount: "無効な値",
+      };
+
+      const result = DraftExpenseSchema.safeParse(invalidData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toHaveLength(2);
+
+        const nameError = result.error.issues.find(
+          (issue) => issue.path[0] === "name",
+        );
+        const amountError = result.error.issues.find(
+          (issue) => issue.path[0] === "amount",
+        );
+
+        expect(nameError?.message).toBe("支出タイトルは必須です");
+        expect(amountError?.message).toBe("支出金額の値が無効です");
+      }
+    });
+  });
+});
+
+describe("createExpense Action", () => {
+  const mockBudgetId = "123456";
+  const mockPrevState = { errors: [], success: "" };
+  let mockFormData: FormData;
+
+  beforeEach(() => {
+    mockFormData = new FormData();
+    mockFormData.append("name", "支出テスト");
+    mockFormData.append("amount", "10000");
+
+    process.env.API_URL = "http://localhost:4000/api";
+
+    mockCreateExpense.mockImplementation(
+      async (budgetId, prevState, formData) => {
+        const name = formData.get("name");
+        const amount = formData.get("amount");
+
+        const validationResult = DraftExpenseSchema.safeParse({
+          name: name as string,
+          amount: amount as string,
+        });
+
+        if (!validationResult.success) {
+          return {
+            errors: validationResult.error.issues.map((issue) => issue.message),
+            success: "",
+          };
+        }
+
+        try {
+          const token = await mockGetToken();
+          const url = `${process.env.API_URL}/budgets/${budgetId}/expenses`;
+
+          const response = { success: "支出が正しく作成されました" };
+          mockRevalidatePath("/admin");
+
+          return {
+            errors: [],
+            success: response.success,
+          };
+        } catch (error) {
+          return {
+            errors: ["エラーが発生しました"],
+            success: "",
+          };
+        }
+      },
+    );
+
+    mockCreateExpense.mockClear();
+    mockRevalidatePath.mockClear();
+    mockGetToken.mockClear();
+  });
+
+  describe("正常なケース", () => {
+    it("正常に支出を作成できるテストケース", async () => {
+      const result = await mockCreateExpense(
+        mockBudgetId,
+        mockPrevState,
+        mockFormData,
+      );
+
+      expect(mockCreateExpense).toHaveBeenCalledWith(
+        mockBudgetId,
+        mockPrevState,
+        mockFormData,
+      );
+
+      expect(result).toEqual({
+        errors: [],
+        success: "支出が正しく作成されました",
+      });
+    });
+
+    it("数値文字列の金額が正しく処理されること", async () => {
+      const stringAmountFormData = new FormData();
+      stringAmountFormData.append("name", "文字列金額テスト");
+      stringAmountFormData.append("amount", "5000");
+
+      const result = await mockCreateExpense(
+        mockBudgetId,
+        mockPrevState,
+        stringAmountFormData,
+      );
+
+      expect(result.errors).toEqual([]);
+      expect(result.success).toBe("支出が正しく作成されました");
+    });
+  });
+
+  describe("バリデーションエラーのケース", () => {
+    it("名前が空の場合、適切なエラーメッセージが返されること", async () => {
+      const invalidFormData = new FormData();
+      invalidFormData.append("name", "");
+      invalidFormData.append("amount", "1000");
+
+      const result = await mockCreateExpense(
+        mockBudgetId,
+        mockPrevState,
+        invalidFormData,
+      );
+
+      expect(result.errors).toContain("支出タイトルは必須です");
+      expect(result.success).toBe("");
+    });
+
+    it("金額が0の場合、適切なエラーメッセージが返されること", async () => {
+      const invalidFormData = new FormData();
+      invalidFormData.append("name", "支出テスト");
+      invalidFormData.append("amount", "0");
+
+      const result = await mockCreateExpense(
+        mockBudgetId,
+        mockPrevState,
+        invalidFormData,
+      );
+
+      expect(result.errors).toContain("支出金額が0円未満です");
+      expect(result.success).toBe("");
+    });
+
+    it("金額が無効な文字列の場合、適切なエラーメッセージが返されること", async () => {
+      const invalidFormData = new FormData();
+      invalidFormData.append("name", "支出テスト");
+      invalidFormData.append("amount", "無効な金額");
+
+      const result = await mockCreateExpense(
+        mockBudgetId,
+        mockPrevState,
+        invalidFormData,
+      );
+
+      expect(result.errors).toContain("支出金額の値が無効です");
+      expect(result.success).toBe("");
+    });
+
+    it("両方のフィールドが無効な場合、複数のエラーが返されること", async () => {
+      const invalidFormData = new FormData();
+      invalidFormData.append("name", "");
+      invalidFormData.append("amount", "無効な金額");
+
+      const result = await mockCreateExpense(
+        mockBudgetId,
+        mockPrevState,
+        invalidFormData,
+      );
+
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors).toContain("支出タイトルは必須です");
+      expect(result.errors).toContain("支出金額の値が無効です");
+      expect(result.success).toBe("");
+    });
+
+    it("フィールドが存在しない場合、バリデーションエラーが返されること", async () => {
+      const emptyFormData = new FormData();
+
+      const result = await mockCreateExpense(
+        mockBudgetId,
+        mockPrevState,
+        emptyFormData,
+      );
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.success).toBe("");
+    });
+  });
+
+  describe("ネットワークエラーのケース", () => {
+    it("APIエラーが発生した場合、適切なエラーメッセージが返されること", async () => {
+      mockCreateExpense.mockImplementationOnce(async () => {
+        throw new Error("Network Error");
+      });
+
+      await expect(
+        mockCreateExpense(mockBudgetId, mockPrevState, mockFormData),
+      ).rejects.toThrow("Network Error");
+    });
+  });
+});

--- a/frontend/src/app/admin/budgets/[id]/layout.tsx
+++ b/frontend/src/app/admin/budgets/[id]/layout.tsx
@@ -15,7 +15,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return(
+  return (
     <html lang="ja">
       <body>
         <ClientThemeProvider>

--- a/frontend/src/app/admin/budgets/[id]/page.test.tsx
+++ b/frontend/src/app/admin/budgets/[id]/page.test.tsx
@@ -1,0 +1,99 @@
+// src/app/admin/budgets/[id]/page.test.tsx
+import { getBudget } from "@/services/budget";
+import { render, screen } from "@testing-library/react";
+import BudgetDetailsPage from "./page";
+
+jest.mock("@/services/budget", () => ({
+  getBudget: jest.fn(),
+}));
+
+jest.mock("@/components/expense/CreateExpenseForm", () => {
+  return jest.fn(({ budgetId }) => (
+    <div data-testid="create-expense-form">支出作成フォーム - {budgetId}</div>
+  ));
+});
+
+jest.mock("@/components/expense/ExpenseList", () => {
+  return jest.fn(({ budget }) => (
+    <div data-testid="expense-list">支出リスト - {budget.name}</div>
+  ));
+});
+
+// Suspenseをモック
+jest.mock("react", () => {
+  const originalReact = jest.requireActual("react");
+  return {
+    ...originalReact,
+    Suspense: ({ children }) => children,
+  };
+});
+
+describe("BudgetDetailsPage", () => {
+  const mockBudget = {
+    id: "budget-123",
+    name: "テスト予算",
+    amount: 100000,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getBudget as jest.Mock).mockResolvedValue(mockBudget);
+  });
+
+  it("予算詳細ページが正しくレンダリングされること", async () => {
+    const mockParams = { id: "budget-123" };
+
+    const page = await BudgetDetailsPage({ params: mockParams });
+    render(page);
+
+    expect(screen.getByText("テスト予算")).toBeInTheDocument();
+
+    expect(screen.getByTestId("create-expense-form")).toBeInTheDocument();
+    expect(screen.getByTestId("expense-list")).toBeInTheDocument();
+  });
+
+  it("getBudgetが正しいIDで呼び出されること", async () => {
+    const mockParams = { id: "budget-456" };
+
+    await BudgetDetailsPage({ params: mockParams });
+
+    expect(getBudget).toHaveBeenCalledWith("budget-456");
+    expect(getBudget).toHaveBeenCalledTimes(1);
+  });
+
+  it("子コンポーネントに正しいpropsが渡されること", async () => {
+    const mockParams = { id: "budget-123" };
+
+    const page = await BudgetDetailsPage({ params: mockParams });
+    render(page);
+
+    expect(
+      screen.getByText("支出作成フォーム - budget-123"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("支出リスト - テスト予算")).toBeInTheDocument();
+  });
+
+  it("getBudgetでエラーが発生した場合もハンドリングされること", async () => {
+    (getBudget as jest.Mock).mockRejectedValue(
+      new Error("予算が見つかりません"),
+    );
+
+    const mockParams = { id: "invalid-id" };
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+    let errorThrown = false;
+
+    try {
+      const page = await BudgetDetailsPage({ params: mockParams });
+      render(page);
+    } catch (e) {
+      errorThrown = true;
+    } finally {
+      consoleSpy.mockRestore();
+    }
+
+    expect(getBudget).toHaveBeenCalledWith("invalid-id");
+  });
+});

--- a/frontend/src/app/admin/budgets/[id]/page.tsx
+++ b/frontend/src/app/admin/budgets/[id]/page.tsx
@@ -12,7 +12,6 @@ export default async function BudgetDetailsPage({
   const { id } = resolvedParams;
 
   const budget = await getBudget(params.id);
-  console.log(budget.expenses, "IDによる支出取得");
 
   return (
     <>

--- a/frontend/src/components/expense/CreateExpenseForm.test.tsx
+++ b/frontend/src/components/expense/CreateExpenseForm.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import CreateExpenseForm from "./CreateExpenseForm";
+
+const mockPush = jest.fn();
+const mockShowMessage = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({ id: "test-id" }),
+}));
+
+jest.mock("../../../context/MessageContext", () => ({
+  useMessage: () => ({
+    showMessage: mockShowMessage,
+  }),
+}));
+
+jest.mock("@mui/material", () => ({
+  Box: ({ children }) => <div>{children}</div>,
+  Dialog: ({ open, children }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }) => <div>{children}</div>,
+  DialogTitle: ({ children }) => <h2>{children}</h2>,
+  FormControl: ({ children }) => <div>{children}</div>,
+  FormHelperText: ({ children }) => <span>{children}</span>,
+  FormLabel: ({ children }) => <label>{children}</label>,
+  TextField: ({ placeholder, id, ...props }) => (
+    <input id={id} placeholder={placeholder} {...props} />
+  ),
+  Slide: ({ children }) => children,
+  useMediaQuery: () => false,
+  useTheme: () => ({ breakpoints: { down: () => false } }),
+}));
+
+jest.mock("@mui/material/transitions", () => ({
+  TransitionProps: {},
+}));
+
+const mockHandleSubmit = jest.fn((cb) => (e) => {
+  e?.preventDefault?.();
+  cb({ name: "Test Expense", amount: 10000 });
+  return true;
+});
+
+jest.mock("react-hook-form", () => {
+  return {
+    useForm: () => ({
+      register: jest.fn((name) => ({ name })),
+      handleSubmit: mockHandleSubmit,
+      formState: {
+        errors: {},
+        isSubmitting: false,
+      },
+      reset: jest.fn(),
+      setValue: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("../../../actions/create-expense-action", () => ({
+  createExpense: jest.fn(() =>
+    Promise.resolve({ errors: [], success: "支出が正しく作成されました" }),
+  ),
+}));
+
+jest.mock("react", () => {
+  const originalModule = jest.requireActual("react");
+  return {
+    ...originalModule,
+    useActionState: jest.fn(() => [{ errors: [], success: "" }, jest.fn()]),
+    useTransition: jest.fn(() => [false, jest.fn()]),
+    useState: jest.fn(() => [true, jest.fn()]),
+    useEffect: jest.fn(),
+    useRef: jest.fn(() => ({ current: null })),
+    forwardRef: (fn) => fn,
+  };
+});
+
+jest.mock("../ui/Button/Button", () => {
+  return jest.fn(({ children, onClick, ...props }) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ));
+});
+
+jest.mock("@hookform/resolvers/zod", () => ({
+  zodResolver: jest.fn(() => ({})),
+}));
+
+describe("CreateExpenseFormコンポーネントのテスト", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockBudgetId = "123456";
+
+  it("新規支出作成ボタンが表示されること", () => {
+    render(<CreateExpenseForm budgetId={mockBudgetId} />);
+
+    expect(
+      screen.getByRole("button", { name: /新規支出作成/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("ダイアログが開いた状態でフォーム要素が表示されること", () => {
+    render(<CreateExpenseForm budgetId={mockBudgetId} />);
+
+    expect(screen.getByText("支出の追加")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/タイトルを入力/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/金額/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /追加/i })).toBeInTheDocument();
+  });
+
+  it("フォーム送信時にhandleSubmitが呼ばれること", () => {
+    render(<CreateExpenseForm budgetId={mockBudgetId} />);
+
+    const submitButton = screen.getByRole("button", { name: /追加/i });
+    fireEvent.click(submitButton);
+
+    expect(mockHandleSubmit).toHaveBeenCalled();
+  });
+
+  it("バリデーションエラーが正しく表示されること", () => {
+    jest
+      .spyOn(require("react-hook-form"), "useForm")
+      .mockImplementationOnce(() => ({
+        register: jest.fn(),
+        handleSubmit: jest.fn(),
+        formState: {
+          errors: {
+            name: { message: "支出タイトルは必須です" },
+            amount: { message: "金額は必須です" },
+          },
+          isSubmitting: false,
+        },
+        reset: jest.fn(),
+        setValue: jest.fn(),
+      }));
+    render(<CreateExpenseForm budgetId={mockBudgetId} />);
+
+    expect(screen.getByText(/支出タイトルは必須です/i)).toBeInTheDocument();
+    expect(screen.getByText(/金額は必須です/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/expense/CreateExpenseForm.tsx
+++ b/frontend/src/components/expense/CreateExpenseForm.tsx
@@ -14,9 +14,6 @@ import {
   useTheme,
 } from "@mui/material";
 import { TransitionProps } from "@mui/material/transitions";
-import { createExpense } from "actions/create-expense-action";
-import { useMessage } from "context/MessageContext";
-import { DraftExpenseFormValues, DraftExpenseSchema } from "libs/schemas/auth";
 import { useParams, useRouter } from "next/navigation";
 import React, {
   useActionState,
@@ -26,6 +23,12 @@ import React, {
   useTransition,
 } from "react";
 import { useForm } from "react-hook-form";
+import { createExpense } from "../../../actions/create-expense-action";
+import { useMessage } from "../../../context/MessageContext";
+import {
+  DraftExpenseFormValues,
+  DraftExpenseSchema,
+} from "../../../libs/schemas/auth";
 import Button from "../ui/Button/Button";
 
 interface CreateExpenseFormProps {


### PR DESCRIPTION
## 概要
#95 

## 変更内容

- サーバーアクションのテストコード実装
- 予算詳細ページのテストコード実装
- 支出一覧テーブルコンポーネントのテストコード実装
- 支出作成ページのテストコード実装
- 支出作成コンポーネントのテストコード実装